### PR TITLE
RedisFactoryLockProvider impl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>shedlock-provider-jdbc-template</module>
         <module>shedlock-provider-zookeeper-curator</module>
         <module>shedlock-provider-hazelcast</module>
+        <module>shedlock-provider-redis-connectionfactory</module>
     </modules>
 
     <properties>

--- a/shedlock-provider-redis-connectionfactory/pom.xml
+++ b/shedlock-provider-redis-connectionfactory/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>shedlock-parent</artifactId>
+		<groupId>net.javacrumbs.shedlock</groupId>
+		<version>0.17.1-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>shedlock-provider-redis-connectionfactory</artifactId>
+	<version>0.17.1-SNAPSHOT</version>
+
+	<properties>
+		<springboot.version>1.5.9.RELEASE</springboot.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.javacrumbs.shedlock</groupId>
+			<artifactId>shedlock-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+			<version>${springboot.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>net.javacrumbs.shedlock</groupId>
+			<artifactId>shedlock-test-support</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+
+		<dependency>
+			<groupId>com.github.kstyrc</groupId>
+			<artifactId>embedded-redis</artifactId>
+			<version>0.6</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>
+								net.javacrumbs.shedlock.provider.redis-connectionfactory
+							</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/shedlock-provider-redis-connectionfactory/src/main/java/net/javacrumbs/shedlock/provider/redisconnectionfactory/RedisFactoryLockProvider.java
+++ b/shedlock-provider-redis-connectionfactory/src/main/java/net/javacrumbs/shedlock/provider/redisconnectionfactory/RedisFactoryLockProvider.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.redisconnectionfactory;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
+import org.springframework.data.redis.core.types.Expiration;
+
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.support.LockException;
+
+/**
+ * Uses Redis's `SET resource-name anystring NX PX max-lock-ms-time` as locking mechanism.
+ * See https://redis.io/commands/set
+ */
+public class RedisFactoryLockProvider implements LockProvider {
+
+	private static final String KEY_PREFIX = "job-lock";
+	private static final String ENV_DEFAULT = "default";
+
+	private RedisConnectionFactory redisConnectionFactory;
+	private String environment;
+
+	public RedisFactoryLockProvider(RedisConnectionFactory redisConn) {
+		this(redisConn, ENV_DEFAULT);
+	}
+
+	public RedisFactoryLockProvider(RedisConnectionFactory redisConn, String environment) {
+		this.redisConnectionFactory = redisConn;
+		this.environment = environment;
+	}
+
+	@Override
+	public Optional<SimpleLock> lock(LockConfiguration lockConfiguration) {
+
+		String key = buildKey(lockConfiguration.getName(), this.environment);
+		RedisConnection redisConnection = null;
+		try {
+			redisConnection = redisConnectionFactory.getConnection();
+
+			if (redisConnection.setNX(key.getBytes(), buildValue().getBytes())) {
+				redisConnection.pExpire(key.getBytes(), getMsUntil(lockConfiguration.getLockAtMostUntil()));
+				return Optional.of(new RedisLock(key, redisConnectionFactory, lockConfiguration));
+			} else return Optional.empty();
+		} catch (Exception e) {
+			return Optional.empty();
+		} finally {
+			if (redisConnection != null) redisConnection.close();
+		}
+	}
+
+	private static final class RedisLock implements SimpleLock {
+
+		private final String key;
+		private final RedisConnectionFactory redisConnectionFactory;
+		private final LockConfiguration lockConfiguration;
+
+		private RedisLock(String key, RedisConnectionFactory redisConnectionFactory, LockConfiguration lockConfiguration) {
+			this.key = key;
+			this.redisConnectionFactory = redisConnectionFactory;
+			this.lockConfiguration = lockConfiguration;
+		}
+
+		@Override
+		public void unlock() {
+			Expiration keepLockFor = Expiration.milliseconds(getMsUntil(lockConfiguration.getLockAtLeastUntil()));
+			RedisConnection redisConnection = null;
+			// lock at least until is in the past
+			if (keepLockFor.getExpirationTimeInMilliseconds() <= 0) {
+				try {
+					redisConnection = redisConnectionFactory.getConnection();
+					redisConnection.del(key.getBytes());
+				} catch (Exception e) {
+					throw new LockException("Can not remove node", e);
+				} finally {
+					if (redisConnection != null) redisConnection.close();
+				}
+			} else {
+				try {
+					redisConnection = redisConnectionFactory.getConnection();
+					redisConnection.set(key.getBytes(), buildValue().getBytes(), keepLockFor, SetOption.SET_IF_PRESENT);
+				} finally {
+					if (redisConnection != null) redisConnection.close();
+				}
+			}
+		}
+	}
+
+	private static long getMsUntil(Instant instant) {
+		return Duration.between(Instant.now(), instant).toMillis();
+	}
+
+	private static String getHostname() {
+		try {
+			return InetAddress.getLocalHost().getHostName();
+		} catch (UnknownHostException e) {
+			return "unknown host";
+		}
+	}
+
+	static String buildKey(String lockName, String env) {
+		return String.format("%s:%s:%s", KEY_PREFIX, env, lockName);
+	}
+
+	private static String buildValue() {
+		return String.format("ADDED:%s@%s", Instant.now().toString(), getHostname());
+	}
+}

--- a/shedlock-provider-redis-connectionfactory/src/test/java/net/javacrumbs/shedlock/provider/redisconnectionfactory/RedisFactoryLockProviderIntegrationTest.java
+++ b/shedlock-provider-redis-connectionfactory/src/test/java/net/javacrumbs/shedlock/provider/redisconnectionfactory/RedisFactoryLockProviderIntegrationTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.redisconnectionfactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.test.support.AbstractLockProviderIntegrationTest;
+import redis.embedded.RedisServer;
+
+import static java.lang.Thread.sleep;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RedisFactoryLockProviderIntegrationTest extends AbstractLockProviderIntegrationTest {
+
+	private static JedisConnectionFactory jedisConnectionFactory;
+	private static RedisServer redisServer;
+	private LockProvider lockProvider;
+
+	private final static int PORT = 6380;
+	private final static String HOST = "localhost";
+	private final static String ENV = "test";
+
+	@BeforeClass
+	public static void startRedis() throws IOException {
+		redisServer = new RedisServer(PORT);
+		redisServer.start();
+	}
+
+	@AfterClass
+	public static void stopRedis() {
+		redisServer.stop();
+	}
+
+	@Before
+	public void createLockProvider() {
+		jedisConnectionFactory = new JedisConnectionFactory();
+		jedisConnectionFactory.setHostName(HOST);
+		jedisConnectionFactory.setPort(PORT);
+		lockProvider = new RedisFactoryLockProvider(jedisConnectionFactory, ENV);
+	}
+
+	@Override
+	protected LockProvider getLockProvider() {
+		return lockProvider;
+	}
+
+	@Override
+	protected void assertUnlocked(String lockName) {
+		RedisConnection redisConnection = null;
+		try {
+			redisConnection = jedisConnectionFactory.getConnection();
+			Assert.assertNull(redisConnection.get(RedisFactoryLockProvider.buildKey(lockName, ENV).getBytes()));
+		} finally {
+			if (redisConnection != null)
+				redisConnection.close();
+		}
+	}
+
+	@Override
+	protected void assertLocked(String lockName) {
+		RedisConnection redisConnection = null;
+		try {
+			redisConnection = jedisConnectionFactory.getConnection();
+			Assert.assertNotNull(redisConnection.get(RedisFactoryLockProvider.buildKey(lockName, ENV).getBytes()));
+		} finally {
+			if (redisConnection != null)
+				redisConnection.close();
+		}
+	}
+
+	@Override
+	public void shouldTimeout() throws InterruptedException {
+		LockConfiguration configWithShortTimeout = lockConfig(LOCK_NAME1, Duration.ofMillis(2), Duration.ZERO);
+		Optional<SimpleLock> lock1 = getLockProvider().lock(configWithShortTimeout);
+		assertThat(lock1).isNotEmpty();
+
+		sleep(5);
+
+		// Get new config with updated timeout
+		configWithShortTimeout = lockConfig(LOCK_NAME1, Duration.ofMillis(2), Duration.ZERO);
+		assertUnlocked(configWithShortTimeout.getName());
+	}
+}

--- a/shedlock-provider-redis-connectionfactory/src/test/resources/logback.xml
+++ b/shedlock-provider-redis-connectionfactory/src/test/resources/logback.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright 2009-2017 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
#47 for this issue.
For this implementation you need SpringBoot.

Configuration is pretty same as the Jedis version but it uses RedisConnectionFactory instead of JedisPool.