### PR TITLE
clearing of LockRegistry

### DIFF
--- a/shedlock-core/src/main/java/net/javacrumbs/shedlock/support/LockRecordRegistry.java
+++ b/shedlock-core/src/main/java/net/javacrumbs/shedlock/support/LockRecordRegistry.java
@@ -37,4 +37,8 @@ class LockRecordRegistry {
     int getSize() {
         return lockRecords.size();
     }
+
+    public void clear() {
+        lockRecords.clear();
+    }
 }

--- a/shedlock-core/src/main/java/net/javacrumbs/shedlock/support/StorageBasedLockProvider.java
+++ b/shedlock-core/src/main/java/net/javacrumbs/shedlock/support/StorageBasedLockProvider.java
@@ -49,6 +49,10 @@ public class StorageBasedLockProvider implements LockProvider {
         this.storageAccessor = storageAccessor;
     }
 
+    public void clearCache() {
+        lockRecordRegistry.clear();
+    }
+
     @Override
     public Optional<SimpleLock> lock(LockConfiguration lockConfiguration) {
         boolean lockObtained = doLock(lockConfiguration);


### PR DESCRIPTION
Many applications use ShedLock and some database migration tool.

Integration tests for those applications might need cleared and re-migrated databases (and possibly insert fresh data for the test).
When clearing and re-migrating the database however, the shedlock-table is also cleared - which is okay, since the locks should be cleared. But unfortunately, this is not sufficcient, as Shedlock maintains a list of recently created locks in memory. These recently created locks cache is not accessible from the integration tests as they are `private final` fields instantiated without dependency-injection.

Currently, this restriction is bypassed by using reflection during runtime and making the fields accessible.

This PR resolves this problem. It allows to clear the memory-maintained locks without making the `private final` fields accessible.