### PR TITLE
be transaction friendly

### DIFF
--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
@@ -16,6 +16,7 @@
 package net.javacrumbs.shedlock.provider.jdbctemplate;
 
 import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
 
@@ -42,11 +43,19 @@ import javax.sql.DataSource;
  * </ol>
  */
 public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
-    public JdbcTemplateLockProvider(DataSource datasource) {
-        this(datasource, "shedlock");
+    public JdbcTemplateLockProvider(JdbcTemplate jdbcTemplate) {
+        this(jdbcTemplate, "shedlock");
     }
 
-    public JdbcTemplateLockProvider(DataSource datasource, String tableName) {
-        super(new JdbcTemplateStorageAccessor(datasource, tableName));
+    public JdbcTemplateLockProvider(DataSource dataSource) {
+        this(new JdbcTemplate(dataSource));
+    }
+
+    public JdbcTemplateLockProvider(DataSource dataSource, String tableName) {
+        this(new JdbcTemplate(dataSource), tableName);
+    }
+
+    public JdbcTemplateLockProvider(JdbcTemplate jdbcTemplate, String tableName) {
+        super(new JdbcTemplateStorageAccessor(jdbcTemplate, tableName));
     }
 }

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
@@ -17,6 +17,7 @@ package net.javacrumbs.shedlock.provider.jdbctemplate;
 
 import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
 
@@ -44,7 +45,15 @@ import javax.sql.DataSource;
  */
 public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
     public JdbcTemplateLockProvider(JdbcTemplate jdbcTemplate) {
-        this(jdbcTemplate, "shedlock");
+        this(jdbcTemplate, (PlatformTransactionManager) null);
+    }
+
+    public JdbcTemplateLockProvider(JdbcTemplate jdbcTemplate, PlatformTransactionManager transactionManager) {
+        this(jdbcTemplate, transactionManager, "shedlock");
+    }
+
+    public JdbcTemplateLockProvider(JdbcTemplate jdbcTemplate, String tableName) {
+        this(jdbcTemplate, null, tableName);
     }
 
     public JdbcTemplateLockProvider(DataSource dataSource) {
@@ -55,7 +64,8 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
         this(new JdbcTemplate(dataSource), tableName);
     }
 
-    public JdbcTemplateLockProvider(JdbcTemplate jdbcTemplate, String tableName) {
-        super(new JdbcTemplateStorageAccessor(jdbcTemplate, tableName));
+    public JdbcTemplateLockProvider(JdbcTemplate jdbcTemplate, PlatformTransactionManager transactionManager, String tableName) {
+        super(new JdbcTemplateStorageAccessor(jdbcTemplate, transactionManager, tableName));
     }
+
 }

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateStorageAccessor.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateStorageAccessor.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2009-2017 the original author or authors.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,12 @@ import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.support.AbstractStorageAccessor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -31,58 +35,72 @@ import static java.util.Objects.requireNonNull;
  * Spring JdbcTemplate based implementation usable in JTA environment
  */
 class JdbcTemplateStorageAccessor extends AbstractStorageAccessor {
-	private final String tableName;
-	private final JdbcTemplate jdbcTemplate;
+    private final String tableName;
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
 
-	JdbcTemplateStorageAccessor(JdbcTemplate jdbcTemplate, String tableName) {
-		this.jdbcTemplate = requireNonNull(jdbcTemplate, "jdbcTemplate can not be null");
-		this.tableName = requireNonNull(tableName, "tableName can not be null");
-	}
+    public JdbcTemplateStorageAccessor(JdbcTemplate jdbcTemplate, PlatformTransactionManager transactionManager, String tableName) {
+        this.jdbcTemplate = requireNonNull(jdbcTemplate, "jdbcTemplate can not be null");
+        this.tableName = requireNonNull(tableName, "tableName can not be null");
+        if (null == transactionManager) {
+            transactionManager = new DataSourceTransactionManager(jdbcTemplate.getDataSource());
+        }
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+        this.transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
 
-	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public boolean insertRecord(LockConfiguration lockConfiguration) {
-		String sql = "INSERT INTO " + tableName + "(name, lock_until, locked_at, locked_by) VALUES(?, ?, ?, ?)";
-		try
-		{
-			int insertedRows = jdbcTemplate.update(sql, preparedStatement -> {
-				preparedStatement.setString(1, lockConfiguration.getName());
-				preparedStatement.setTimestamp(2, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
-				preparedStatement.setTimestamp(3, Timestamp.from(Instant.now()));
-				preparedStatement.setString(4, getHostname());
-			});
-			return insertedRows > 0;
-		}
-		catch (DataIntegrityViolationException e)
-		{
-			return false;
-		}
-	}
+    JdbcTemplateStorageAccessor(JdbcTemplate jdbcTemplate, String tableName) {
+        this(jdbcTemplate, null, tableName);
+    }
 
-	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public boolean updateRecord(LockConfiguration lockConfiguration) {
-		String sql = "UPDATE " + tableName
-		             + " SET lock_until = ?, locked_at = ?, locked_by = ? WHERE name = ? AND lock_until <= ?";
-		int updatedRows = jdbcTemplate.update(sql, statement -> {
-			Timestamp now = Timestamp.from(Instant.now());
-			statement.setTimestamp(1, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
-			statement.setTimestamp(2, now);
-			statement.setString(3, getHostname());
-			statement.setString(4, lockConfiguration.getName());
-			statement.setTimestamp(5, now);
-		});
-		return updatedRows > 0;
-	}
+    @Override
+    public boolean insertRecord(LockConfiguration lockConfiguration) {
+        String sql = "INSERT INTO " + tableName + "(name, lock_until, locked_at, locked_by) VALUES(?, ?, ?, ?)";
+        return transactionTemplate.execute(status -> {
+            try {
+                int insertedRows = jdbcTemplate.update(sql, preparedStatement -> {
+                    preparedStatement.setString(1, lockConfiguration.getName());
+                    preparedStatement.setTimestamp(2, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
+                    preparedStatement.setTimestamp(3, Timestamp.from(Instant.now()));
+                    preparedStatement.setString(4, getHostname());
+                });
+                return insertedRows > 0;
+            } catch (DataIntegrityViolationException e) {
+                return false;
+            }
+        });
+    }
 
-	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void unlock(LockConfiguration lockConfiguration) {
-		String sql = "UPDATE " + tableName + " SET lock_until = ? WHERE name = ?";
-		jdbcTemplate.update(sql, statement -> {
-			statement.setTimestamp(1, Timestamp.from(lockConfiguration.getUnlockTime()));
-			statement.setString(2, lockConfiguration.getName());
-		});
-	}
+    @Override
+    public boolean updateRecord(LockConfiguration lockConfiguration) {
+        String sql = "UPDATE " + tableName
+            + " SET lock_until = ?, locked_at = ?, locked_by = ? WHERE name = ? AND lock_until <= ?";
+        return transactionTemplate.execute(status -> {
+            int updatedRows = jdbcTemplate.update(sql, statement -> {
+                Timestamp now = Timestamp.from(Instant.now());
+                statement.setTimestamp(1, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
+                statement.setTimestamp(2, now);
+                statement.setString(3, getHostname());
+                statement.setString(4, lockConfiguration.getName());
+                statement.setTimestamp(5, now);
+            });
+            return updatedRows > 0;
+        });
+    }
+
+    @Override
+    public void unlock(LockConfiguration lockConfiguration) {
+        String sql = "UPDATE " + tableName + " SET lock_until = ? WHERE name = ?";
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+
+                jdbcTemplate.update(sql, statement -> {
+                    statement.setTimestamp(1, Timestamp.from(lockConfiguration.getUnlockTime()));
+                    statement.setString(2, lockConfiguration.getName());
+                });
+            }
+        });
+    }
 
 }

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateStorageAccessor.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateStorageAccessor.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2009-2017 the original author or authors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,47 +15,74 @@
  */
 package net.javacrumbs.shedlock.provider.jdbctemplate;
 
-import net.javacrumbs.shedlock.provider.jdbc.internal.AbstractJdbcStorageAccessor;
-import org.springframework.dao.DataAccessException;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.support.AbstractStorageAccessor;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
-import org.springframework.jdbc.support.SQLExceptionTranslator;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.sql.DataSource;
-import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static java.util.Objects.requireNonNull;
 
 /**
- * Spring JdbcTemplate based implementation which at the end does not use much from JdbcTemplate except
- * exception translator. The reason is that we rely on atomic JDBC operations and thus do not want to
- * participate in transactions. It's not easy to not use transactions with JdbcTemplate and since we were using
- * only exception translation, it makes sense to skip JdbcTemplate completely.
+ * Spring JdbcTemplate based implementation usable in JTA environment
  */
-class JdbcTemplateStorageAccessor extends AbstractJdbcStorageAccessor {
-    private final SQLExceptionTranslator exceptionTranslator;
+class JdbcTemplateStorageAccessor extends AbstractStorageAccessor {
+	private final String tableName;
+	private final JdbcTemplate jdbcTemplate;
 
-    JdbcTemplateStorageAccessor(DataSource dataSource, String tableName) {
-        super(dataSource, tableName);
-        this.exceptionTranslator = new SQLErrorCodeSQLExceptionTranslator(dataSource);
-    }
+	JdbcTemplateStorageAccessor(JdbcTemplate jdbcTemplate, String tableName) {
+		this.jdbcTemplate = requireNonNull(jdbcTemplate, "jdbcTemplate can not be null");
+		this.tableName = requireNonNull(tableName, "tableName can not be null");
+	}
 
-    @Override
-    protected void handleInsertionException(String sql, SQLException e) {
-        DataAccessException translatedException = exceptionTranslator.translate("InsertLock", sql, e);
-        if (translatedException instanceof DataIntegrityViolationException) {
-            // lock record already exists
-            // DuplicateKeyException is not enough for Vertica
-        } else {
-            throw translatedException;
-        }
-    }
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public boolean insertRecord(LockConfiguration lockConfiguration) {
+		String sql = "INSERT INTO " + tableName + "(name, lock_until, locked_at, locked_by) VALUES(?, ?, ?, ?)";
+		try
+		{
+			int insertedRows = jdbcTemplate.update(sql, preparedStatement -> {
+				preparedStatement.setString(1, lockConfiguration.getName());
+				preparedStatement.setTimestamp(2, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
+				preparedStatement.setTimestamp(3, Timestamp.from(Instant.now()));
+				preparedStatement.setString(4, getHostname());
+			});
+			return insertedRows > 0;
+		}
+		catch (DataIntegrityViolationException e)
+		{
+			return false;
+		}
+	}
 
-    @Override
-    protected void handleUpdateException(String sql, SQLException e) {
-        throw exceptionTranslator.translate("UpdateLock", sql, e);
-    }
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public boolean updateRecord(LockConfiguration lockConfiguration) {
+		String sql = "UPDATE " + tableName
+		             + " SET lock_until = ?, locked_at = ?, locked_by = ? WHERE name = ? AND lock_until <= ?";
+		int updatedRows = jdbcTemplate.update(sql, statement -> {
+			Timestamp now = Timestamp.from(Instant.now());
+			statement.setTimestamp(1, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
+			statement.setTimestamp(2, now);
+			statement.setString(3, getHostname());
+			statement.setString(4, lockConfiguration.getName());
+			statement.setTimestamp(5, now);
+		});
+		return updatedRows > 0;
+	}
 
-    @Override
-    protected void handleUnlockException(String sql, SQLException e) {
-        throw exceptionTranslator.translate("Unlock", sql, e);
-    }
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void unlock(LockConfiguration lockConfiguration) {
+		String sql = "UPDATE " + tableName + " SET lock_until = ? WHERE name = ?";
+		jdbcTemplate.update(sql, statement -> {
+			statement.setTimestamp(1, Timestamp.from(lockConfiguration.getUnlockTime()));
+			statement.setString(2, lockConfiguration.getName());
+		});
+	}
+
 }


### PR DESCRIPTION
  use jdbcTemplate (which internally uses DataSourceUtils.getConnection())
  use @Transactional with Propagation.REQUIRES_NEW

I think using connection.setAutoCommit(true) might lead to problems especially when using JTA transactions, so I propose changing at least JdbcTemplateStorageAccessor to use Springs @Transactional annotation. Additionally, JdbcTemplateLockProvider can use an existing JdbcTemplate.