### PR TITLE
Don't cache MongoLockProvider in the integration test

### DIFF
--- a/providers/mongo/shedlock-provider-mongo/src/test/java/net/javacrumbs/shedlock/provider/mongo/MongoLockProviderIntegrationTest.java
+++ b/providers/mongo/shedlock-provider-mongo/src/test/java/net/javacrumbs/shedlock/provider/mongo/MongoLockProviderIntegrationTest.java
@@ -30,10 +30,7 @@ import java.net.UnknownHostException;
 import java.util.Date;
 
 import static com.mongodb.client.model.Filters.eq;
-import static net.javacrumbs.shedlock.provider.mongo.MongoLockProvider.ID;
-import static net.javacrumbs.shedlock.provider.mongo.MongoLockProvider.LOCKED_AT;
-import static net.javacrumbs.shedlock.provider.mongo.MongoLockProvider.LOCKED_BY;
-import static net.javacrumbs.shedlock.provider.mongo.MongoLockProvider.LOCK_UNTIL;
+import static net.javacrumbs.shedlock.provider.mongo.MongoLockProvider.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MongoLockProviderIntegrationTest extends AbstractLockProviderIntegrationTest {
@@ -41,19 +38,17 @@ public class MongoLockProviderIntegrationTest extends AbstractLockProviderIntegr
 
     private static final String COLLECTION_NAME = "Shedlock";
     private static final String DB_NAME = "db";
-    private MongoLockProvider lockProvider;
     private MongoClient mongo;
 
     @Before
     public void createLockProvider() throws UnknownHostException {
         mongo = mongoFactory.newMongo();
         mongo.getDatabase(DB_NAME).drop();
-        lockProvider = new MongoLockProvider(mongo, DB_NAME, COLLECTION_NAME);
     }
 
     @Override
     protected LockProvider getLockProvider() {
-        return lockProvider;
+        return new MongoLockProvider(mongo, DB_NAME, COLLECTION_NAME);
     }
 
     @Override
@@ -86,7 +81,7 @@ public class MongoLockProviderIntegrationTest extends AbstractLockProviderIntegr
     }
 
     @AfterClass
-    public static void stopMongo() throws IOException {
+    public static void stopMongo() {
         mongoFactory.shutdown();
     }
 }

--- a/shedlock-test-support/src/main/java/net/javacrumbs/shedlock/test/support/AbstractLockProviderIntegrationTest.java
+++ b/shedlock-test-support/src/main/java/net/javacrumbs/shedlock/test/support/AbstractLockProviderIntegrationTest.java
@@ -101,10 +101,9 @@ public abstract class AbstractLockProviderIntegrationTest {
     @Test
     public void shouldBeAbleToLockRightAfterUnlock() {
         LockConfiguration lockConfiguration = lockConfig(LOCK_NAME1);
-        LockProvider lockProvider = getLockProvider();
         for (int i = 0; i < 100; i++) {
-            Optional<SimpleLock> lock = lockProvider.lock(lockConfiguration);
-            assertThat(lockProvider.lock(lockConfiguration)).isEmpty();
+            Optional<SimpleLock> lock = getLockProvider().lock(lockConfiguration);
+            assertThat(getLockProvider().lock(lockConfiguration)).isEmpty();
             assertThat(lock).isNotEmpty();
             lock.get().unlock();
         }


### PR DESCRIPTION
The properties tested in the abstract test suite should still hold, even when the lock provider is created on demand (it's synonymous to multiple clients trying to acquire the lock). Unfortunately, when only a single instance is used in the test, it's easy to make an uncaught mistake when writing a custom implementation. In my case I've made an error of using regular `set` updates in my `insertRecord` implementation (instead of correct `setOnInsert`) and all tests still passed.