### PR TITLE
Init hostname once

### DIFF
--- a/shedlock-core/src/main/java/net/javacrumbs/shedlock/support/Utils.java
+++ b/shedlock-core/src/main/java/net/javacrumbs/shedlock/support/Utils.java
@@ -18,11 +18,18 @@ package net.javacrumbs.shedlock.support;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-public class Utils {
+public final class Utils {
+
+    private static final String hostname = initHostname();
+
     private Utils() {
     }
 
     public static String getHostname() {
+        return hostname;
+    }
+
+    private static String initHostname() {
         try {
             return InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {


### PR DESCRIPTION
Getting the hostname is quite costly. Especially on slow networks. Since it won't change, caching it seems the good way to do it.