### PR TITLE
DynamoDB: Cleanup imports and add copyright header

### DIFF
--- a/providers/dynamodb/shedlock-provider-dynamodb/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBLockProvider.java
+++ b/providers/dynamodb/shedlock-provider-dynamodb/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBLockProvider.java
@@ -15,32 +15,18 @@
  */
 package net.javacrumbs.shedlock.provider.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Table;
 import com.amazonaws.services.dynamodbv2.document.UpdateItemOutcome;
 import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
 import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ResourceInUseException;
 import com.amazonaws.services.dynamodbv2.model.ReturnValue;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.core.SimpleLock;
 import net.javacrumbs.shedlock.support.Utils;
 
 import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.Optional;
 
 import static net.javacrumbs.shedlock.support.Utils.toIsoString;

--- a/providers/dynamodb/shedlock-provider-dynamodb/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBUtils.java
+++ b/providers/dynamodb/shedlock-provider-dynamodb/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2009-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.javacrumbs.shedlock.provider.dynamodb;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
@@ -10,7 +25,6 @@ import com.amazonaws.services.dynamodbv2.model.KeyType;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazonaws.services.dynamodbv2.model.ResourceInUseException;
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 
 import static net.javacrumbs.shedlock.provider.dynamodb.DynamoDBLockProvider.ID;
 


### PR DESCRIPTION
Just minor after cleanups of imports and adding Copyright header to Utils class. Forgot those earlier and somehow IDEA didn't pick the imports up.