### PR TITLE
Finding class level annotation in proxy method mode

### DIFF
--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/internal/SpringLockConfigurationExtractor.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/internal/SpringLockConfigurationExtractor.java
@@ -133,7 +133,7 @@ public class SpringLockConfigurationExtractor implements LockConfigurationExtrac
         } else {
             // Try to find annotation on proxied class
             Class<?> targetClass = AopUtils.getTargetClass(target);
-            if (targetClass != null && !target.getClass().equals(targetClass)) {
+            if (targetClass != null) {
                 try {
                     Method methodOnTarget = targetClass
                         .getMethod(method.getName(), method.getParameterTypes());

--- a/spring/shedlock-spring/src/test/java/net/javacrumbs/shedlock/spring/aop/MethodProxyAopConfig.java
+++ b/spring/shedlock-spring/src/test/java/net/javacrumbs/shedlock/spring/aop/MethodProxyAopConfig.java
@@ -46,6 +46,11 @@ public class MethodProxyAopConfig {
         return new TestBean();
     }
 
+    @Bean
+    public AnotherTestBean anotherTestBean() {
+        return new AnotherTestBeanImpl();
+    }
+
     static class TestBean {
 
         public void noAnnotation() {
@@ -72,6 +77,19 @@ public class MethodProxyAopConfig {
 
         @SchedulerLock(name = "${property.value}", lockAtLeastFor = 1_000)
         public void spel() {
+
+        }
+    }
+
+    interface AnotherTestBean {
+        void runManually();
+    }
+
+    static class AnotherTestBeanImpl implements AnotherTestBean {
+
+        @Override
+        @SchedulerLock(name = "classAnnotation")
+        public void runManually() {
 
         }
     }

--- a/spring/shedlock-spring/src/test/java/net/javacrumbs/shedlock/spring/aop/MethodProxyAopTest.java
+++ b/spring/shedlock-spring/src/test/java/net/javacrumbs/shedlock/spring/aop/MethodProxyAopTest.java
@@ -17,6 +17,7 @@ package net.javacrumbs.shedlock.spring.aop;
 
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.spring.aop.MethodProxyAopConfig.AnotherTestBean;
 import net.javacrumbs.shedlock.spring.aop.MethodProxyAopConfig.TestBean;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +47,9 @@ public class MethodProxyAopTest {
 
     @Autowired
     private TestBean testBean;
+
+    @Autowired
+    private AnotherTestBean anotherTestBean;
 
     private final SimpleLock simpleLock = mock(SimpleLock.class);
 
@@ -94,5 +98,12 @@ public class MethodProxyAopTest {
         testBean.spel();
         verify(lockProvider).lock(hasParams("spel", 30_000, 1_000));
         verify(simpleLock).unlock();
+    }
+
+    @Test
+    public void shouldReadAnnotationFromImplementationClass() {
+      anotherTestBean.runManually();
+      verify(lockProvider).lock(hasParams("classAnnotation", 30_000, 100));
+      verify(simpleLock).unlock();
     }
 }


### PR DESCRIPTION
Please correct me if I am wrong.

Currently class level SchedulerLock annotation is not found (PROXY_METHOD mode). There are two proxy tests for JDK and class proxies in internal.SpringLockConfigurationExtractorTest. But neither one tests regular Spring bean (implementing interface) to be proxied by ShedLock.