### PR TITLE
Support custom clock for lock configuration

### DIFF
--- a/shedlock-core/src/main/java/net/javacrumbs/shedlock/core/LockConfiguration.java
+++ b/shedlock-core/src/main/java/net/javacrumbs/shedlock/core/LockConfiguration.java
@@ -15,6 +15,7 @@
  */
 package net.javacrumbs.shedlock.core;
 
+import java.time.Clock;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
@@ -36,18 +37,29 @@ public class LockConfiguration {
      */
     private final Instant lockAtLeastUntil;
 
+    private final Clock clock;
+
     public LockConfiguration(@NotNull String name, @NotNull Instant lockAtMostUntil) {
-        this(name, lockAtMostUntil, Instant.now());
+        this(name, lockAtMostUntil, Instant.now(), Clock.systemUTC());
+    }
+
+    public LockConfiguration(@NotNull String name, @NotNull Instant lockAtMostUntil, @NotNull Clock clock) {
+        this(name, lockAtMostUntil, Instant.now(clock), clock);
     }
 
     public LockConfiguration(@NotNull String name, @NotNull Instant lockAtMostUntil, @NotNull Instant lockAtLeastUntil) {
+        this(name, lockAtMostUntil, lockAtLeastUntil, Clock.systemUTC());
+    }
+
+    public LockConfiguration(@NotNull String name, @NotNull Instant lockAtMostUntil, @NotNull Instant lockAtLeastUntil, @NotNull Clock clock) {
         this.name = Objects.requireNonNull(name);
         this.lockAtMostUntil = Objects.requireNonNull(lockAtMostUntil);
         this.lockAtLeastUntil = Objects.requireNonNull(lockAtLeastUntil);
+        this.clock = Objects.requireNonNull(clock);
         if (lockAtLeastUntil.isAfter(lockAtMostUntil)) {
             throw new IllegalArgumentException("lockAtMostUntil is before lockAtLeastUntil for lock '" + name + "'.");
         }
-        if (lockAtMostUntil.isBefore(Instant.now())) {
+        if (lockAtMostUntil.isBefore(Instant.now(clock))) {
             throw new IllegalArgumentException("lockAtMostUntil is in the past for lock '" + name + "'.");
         }
         if (name.isEmpty()) {
@@ -72,7 +84,7 @@ public class LockConfiguration {
      * Returns either now or lockAtLeastUntil whichever is later.
      */
     public Instant getUnlockTime() {
-        Instant now = Instant.now();
+        Instant now = Instant.now(clock);
         return lockAtLeastUntil.isAfter(now) ? lockAtLeastUntil : now;
     }
 

--- a/shedlock-core/src/test/java/net/javacrumbs/shedlock/core/LockConfigurationTest.java
+++ b/shedlock-core/src/test/java/net/javacrumbs/shedlock/core/LockConfigurationTest.java
@@ -15,17 +15,23 @@
  */
 package net.javacrumbs.shedlock.core;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 class LockConfigurationTest {
 
     @Test
-    void lockAtLeastUnitilShouldBeBeforeOrEqualsToLockAtMostUntil() {
+    void lockAtLeastUntilShouldBeBeforeOrEqualsToLockAtMostUntil() {
         Instant time = Instant.now().plusSeconds(5);
         new LockConfiguration("name", time, time);
         new LockConfiguration("name", time.plusMillis(1), time);
@@ -39,10 +45,31 @@ class LockConfigurationTest {
         assertThatThrownBy(() -> new LockConfiguration("name", now.minusSeconds(1))).isInstanceOf(IllegalArgumentException.class);
     }
 
-
     @Test
     void nameShouldNotBeEmpty() {
         assertThatThrownBy(() -> new LockConfiguration("", Instant.now().plusSeconds(5))).isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void defaultClockSystemUTC() {
+        Instant now = Instant.now();
+
+        LockConfiguration lockConfiguration = new LockConfiguration("name", now.plusSeconds(5));
+
+        assertThat(lockConfiguration.getLockAtLeastUntil()).isAfterOrEqualTo(now);
+        assertThat(lockConfiguration.getLockAtMostUntil()).isEqualTo(now.plusSeconds(5));
+        assertThat(lockConfiguration.getUnlockTime()).isAfterOrEqualTo(now);
+    }
+
+    @Test
+    void canPassCustomClock() {
+        ZoneId zoneId = ZoneId.of("Europe/Helsinki");
+        LocalDateTime fixedTime = LocalDateTime.of(LocalDate.of(2020, 2, 14), LocalTime.MIDNIGHT);
+        Clock fixedClock = Clock.fixed(fixedTime.atZone(zoneId).toInstant(), zoneId);
+
+        LockConfiguration lockConfiguration = new LockConfiguration("name", Instant.now(fixedClock).plusSeconds(5), fixedClock);
+        assertThat(lockConfiguration.getLockAtLeastUntil()).isEqualTo(fixedClock.instant());
+        assertThat(lockConfiguration.getLockAtMostUntil()).isEqualTo(fixedClock.instant().plusSeconds(5));
+        assertThat(lockConfiguration.getUnlockTime()).isEqualTo(fixedClock.instant());
+    }
 }


### PR DESCRIPTION
Add support for custom clock for lock configuration as for unit-tests this is the preferred option.