### PR TITLE
Migrated original shedlock-provider-dynamodb to shedlock-provider-dyn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ executed repeatedly.
   - [JdbcTemplate](#jdbctemplate)
   - [Mongo](#mongo)
   - [DynamoDB](#dynamodb)
+  - [DynamoDB Legacy](#dynamodb-legacy)
   - [ZooKeeper (using Curator)](#zookeeper-using-curator)
   - [Redis (using Spring RedisConnectionFactory)](#redis-using-spring-redisconnectionfactory)
   - [Redis (using Jedis)](#redis-using-jedis)
@@ -58,7 +59,7 @@ First of all, we have to import the project
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-spring</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -147,7 +148,7 @@ Add dependency
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-provider-jdbc-template</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -194,7 +195,7 @@ Import the project
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-provider-mongo</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -214,13 +215,45 @@ public LockProvider lockProvider(MongoClient mongo) {
 Please note that MongoDB integration requires Mongo >= 2.4 and mongo-java-driver >= 3.4.0
 
 #### DynamoDB
+This depends on AWS SDK v2.
+
 Import the project
 
  ```xml
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-provider-dynamodb</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
+</dependency>
+```
+
+Configure:
+
+ ```java
+import net.javacrumbs.shedlock.provider.dynamodb.DynamoDBLockProvider;
+
+...
+
+@Bean
+public LockProvider lockProvider(software.amazon.awssdk.services.dynamodb.DynamoDbClient dynamoDB) {
+    return new DynamoDBLockProvider(dynamoDB, "existingTableName");
+}
+```
+
+> Please note that the lock table must be created externally.
+> `DynamoDBUtils#createLockTable` may be used for creating it programmatically.
+> A table definition is available from `DynamoDBLockProvider`'s Javadoc.
+
+#### DynamoDB Legacy
+This depends on AWS SDK v1.
+
+Import the project
+
+ ```xml
+<dependency>
+    <groupId>net.javacrumbs.shedlock</groupId>
+    <artifactId>shedlock-provider-dynamodb-legacy</artifactId>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -247,7 +280,7 @@ Import
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-provider-zookeeper-curator</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -271,7 +304,7 @@ Import
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-provider-redis-spring</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -302,7 +335,7 @@ Import
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-provider-redis-jedis</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -379,7 +412,7 @@ I am really not sure that it's a good idea to use Elasticsearch as a lock provid
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-provider-elasticsearch</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -446,7 +479,7 @@ Import the project:
 <dependency>
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-micronaut</artifactId>
-    <version>4.7.1</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -566,6 +599,11 @@ after each other, `lockAtLeastFor` can prevent it.
 ## Requirements and dependencies
 * Java 8
 * slf4j-api
+
+# Release notes
+## 5.0.0
+* Migraged original DynamoDB provider based on v1 of AWS SDK to shedlock-provider-dynamodb-legacy
+* Refactored shedlock-provider-dynamodb to use v2 of AWS SDK
 
 # Release notes
 ## 4.7.1

--- a/micronaut/micronaut-test/pom.xml
+++ b/micronaut/micronaut-test/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>micronaut-test</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <properties>
         <micronaut.version>1.1.0.RC2</micronaut.version>

--- a/micronaut/shedlock-micronaut/pom.xml
+++ b/micronaut/shedlock-micronaut/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>shedlock-micronaut</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <properties>
         <micronaut.version>1.2.6</micronaut.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>net.javacrumbs.shedlock</groupId>
     <artifactId>shedlock-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <modules>
         <module>shedlock-core</module>
         <module>micronaut/shedlock-micronaut</module>
@@ -44,6 +44,7 @@
         <module>providers/redis/shedlock-provider-redis-jedis</module>
         <module>providers/redis/shedlock-provider-redis-spring</module>
         <module>providers/redis/shedlock-provider-redis-spring-1</module>
+        <module>providers/dynamodb/shedlock-provider-dynamodb-legacy</module>
         <module>providers/dynamodb/shedlock-provider-dynamodb</module>
         <module>providers/cassandra/shedlock-provider-cassandra</module>
     </modules>

--- a/providers/cassandra/shedlock-provider-cassandra/pom.xml
+++ b/providers/cassandra/shedlock-provider-cassandra/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-cassandra</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <properties>
         <java-driver.version>4.3.1</java-driver.version>

--- a/providers/couchbase/shedlock-provider-couchbase-javaclient/pom.xml
+++ b/providers/couchbase/shedlock-provider-couchbase-javaclient/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-couchbase-javaclient</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/providers/dynamodb/shedlock-provider-dynamodb-legacy/pom.xml
+++ b/providers/dynamodb/shedlock-provider-dynamodb-legacy/pom.xml
@@ -8,20 +8,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>shedlock-provider-dynamodb</artifactId>
+    <artifactId>shedlock-provider-dynamodb-legacy</artifactId>
     <version>5.0.0-SNAPSHOT</version>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>bom</artifactId>
-                <version>2.11.12</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -31,20 +19,15 @@
         </dependency>
 
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>dynamodb</artifactId>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>1.11.463</version>
         </dependency>
 
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>DynamoDBLocal</artifactId>
             <version>1.11.119</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.13.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/providers/dynamodb/shedlock-provider-dynamodb-legacy/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBLockProvider.java
+++ b/providers/dynamodb/shedlock-provider-dynamodb-legacy/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBLockProvider.java
@@ -15,6 +15,12 @@
  */
 package net.javacrumbs.shedlock.provider.dynamodb;
 
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.document.UpdateItemOutcome;
+import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
+import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.ReturnValue;
 import net.javacrumbs.shedlock.core.AbstractSimpleLock;
 import net.javacrumbs.shedlock.core.ClockProvider;
 import net.javacrumbs.shedlock.core.LockConfiguration;
@@ -22,24 +28,15 @@ import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.core.SimpleLock;
 import net.javacrumbs.shedlock.support.Utils;
 import org.jetbrains.annotations.NotNull;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
-import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
-import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
 
 import java.time.Instant;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import static net.javacrumbs.shedlock.support.Utils.toIsoString;
 
 /**
  * Distributed lock using DynamoDB.
- * Depends on <code>software.amazon.awssdk:dynamodb</code>.
+ * Depends on <code>aws-java-sdk-dynamodb</code>.
  * <p>
  * It uses a table with the following structure:
  * <pre>
@@ -84,19 +81,16 @@ public class DynamoDBLockProvider implements LockProvider {
             "set " + LOCK_UNTIL + " = :lockUntil";
 
     private final String hostname;
-    private final DynamoDbClient ddbClient;
-    private final String tableName;
+    private final Table table;
 
     /**
      * Uses DynamoDB to coordinate locks
      *
-     * @param ddbClient v2 of DynamoDB client
-     * @param tableName the lock table name
+     * @param table existing DynamoDB table to be used
      */
-    public DynamoDBLockProvider(@NotNull DynamoDbClient ddbClient, String tableName) {
-        this.ddbClient = ddbClient;
+    public DynamoDBLockProvider(@NotNull Table table) {
+        this.table = table;
         this.hostname = Utils.getHostname();
-        this.tableName = tableName;
     }
 
     @Override
@@ -105,37 +99,24 @@ public class DynamoDBLockProvider implements LockProvider {
         String nowIso = toIsoString(now());
         String lockUntilIso = toIsoString(lockConfiguration.getLockAtMostUntil());
 
-        Map<String, AttributeValue> key = Collections.singletonMap(ID, AttributeValue.builder()
-                .s(lockConfiguration.getName())
-                .build());
-
-        Map<String, AttributeValue> attributeUpdates = new HashMap<>(3);
-        attributeUpdates.put(":lockUntil", AttributeValue.builder()
-                        .s(lockUntilIso)
-                        .build());
-        attributeUpdates.put(":lockedAt", AttributeValue.builder()
-                        .s(nowIso)
-                        .build());
-        attributeUpdates.put(":lockedBy", AttributeValue.builder()
-                        .s(hostname)
-                        .build());
-
-        UpdateItemRequest request = UpdateItemRequest.builder()
-                .tableName("jobs")
-                .key(key)
-                .updateExpression(OBTAIN_LOCK_QUERY)
-                .conditionExpression(OBTAIN_LOCK_CONDITION)
-                .expressionAttributeValues(attributeUpdates)
-                .returnValues(ReturnValue.UPDATED_NEW)
-                .build();
+        UpdateItemSpec request = new UpdateItemSpec()
+                .withPrimaryKey(ID, lockConfiguration.getName())
+                .withUpdateExpression(OBTAIN_LOCK_QUERY)
+                .withConditionExpression(OBTAIN_LOCK_CONDITION)
+                .withValueMap(new ValueMap()
+                        .withString(":lockUntil", lockUntilIso)
+                        .withString(":lockedAt", nowIso)
+                        .withString(":lockedBy", hostname)
+                )
+                .withReturnValues(ReturnValue.UPDATED_NEW);
 
         try {
             // There are three possible situations:
             // 1. The lock document does not exist yet - it is inserted - we have the lock
             // 2. The lock document exists and lockUtil <= now - it is updated - we have the lock
             // 3. The lock document exists and lockUtil > now - ConditionalCheckFailedException is thrown
-            UpdateItemResponse response = ddbClient.updateItem(request);
-            assert lockUntilIso.equals(response.getValueForField(LOCK_UNTIL, String.class));
+            UpdateItemOutcome updated = table.updateItem(request);
+            assert lockUntilIso.equals(updated.getItem().getString(LOCK_UNTIL));
             return Optional.of(new DynamoDBLock(lockConfiguration));
         } catch (ConditionalCheckFailedException e) {
             // Condition failed. This means there was a lock with lockUntil > now.
@@ -156,26 +137,15 @@ public class DynamoDBLockProvider implements LockProvider {
         public void doUnlock() {
             // Set lockUntil to now or lockAtLeastUntil whichever is later
             String unlockTimeIso = toIsoString(lockConfiguration.getUnlockTime());
-
-            Map<String, AttributeValue> key = Collections.singletonMap(ID, AttributeValue.builder()
-                    .s(lockConfiguration.getName())
-                    .build());
-
-            Map<String, AttributeValue> attributeUpdates = Collections.singletonMap(":lockUntil", AttributeValue.builder()
-                            .s(unlockTimeIso)
-                            .build());
-
-
-            UpdateItemRequest request = UpdateItemRequest.builder()
-                    .tableName(tableName)
-                    .key(key)
-                    .updateExpression(RELEASE_LOCK_QUERY)
-                    .expressionAttributeValues(attributeUpdates)
-                    .returnValues(ReturnValue.UPDATED_NEW)
-                    .build();
-
-            UpdateItemResponse response = ddbClient.updateItem(request);
-            assert unlockTimeIso.equals(response.getValueForField(LOCK_UNTIL, String.class));
+            UpdateItemSpec request = new UpdateItemSpec()
+                    .withPrimaryKey(ID, lockConfiguration.getName())
+                    .withUpdateExpression(RELEASE_LOCK_QUERY)
+                    .withValueMap(new ValueMap()
+                            .withString(":lockUntil", unlockTimeIso)
+                    )
+                    .withReturnValues(ReturnValue.UPDATED_NEW);
+            UpdateItemOutcome updated = table.updateItem(request);
+            assert unlockTimeIso.equals(updated.getItem().getString(LOCK_UNTIL));
         }
     }
 }

--- a/providers/dynamodb/shedlock-provider-dynamodb-legacy/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBUtils.java
+++ b/providers/dynamodb/shedlock-provider-dynamodb-legacy/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBUtils.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeyType;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.ResourceInUseException;
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+
+import static net.javacrumbs.shedlock.provider.dynamodb.DynamoDBLockProvider.ID;
+
+public class DynamoDBUtils {
+
+    /**
+     * Creates a locking table with the given name.
+     * <p>
+     * This method does not check if a table with the given name exists already.
+     *
+     * @param dynamodb   DynamoDB to be used
+     * @param tableName  table to be used
+     * @param throughput AWS {@link ProvisionedThroughput throughput requirements} for the given lock setup
+     * @return           a {@link Table reference to the newly created table}
+     *
+     * @throws ResourceInUseException
+     *         The operation conflicts with the resource's availability. You attempted to recreate an
+     *         existing table.
+     */
+    public static Table createLockTable(
+            AmazonDynamoDB dynamodb,
+            String tableName,
+            ProvisionedThroughput throughput
+    ) {
+
+        CreateTableRequest request = new CreateTableRequest()
+                .withTableName(tableName)
+                .withKeySchema(new KeySchemaElement(ID, KeyType.HASH))
+                .withAttributeDefinitions(new AttributeDefinition(ID, ScalarAttributeType.S))
+                .withProvisionedThroughput(throughput);
+        dynamodb.createTable(request).getTableDescription();
+        return new DynamoDB(dynamodb).getTable(tableName);
+    }
+}

--- a/providers/dynamodb/shedlock-provider-dynamodb-legacy/src/test/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBLockProviderIntegrationTest.java
+++ b/providers/dynamodb/shedlock-provider-dynamodb-legacy/src/test/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBLockProviderIntegrationTest.java
@@ -15,23 +15,22 @@
  */
 package net.javacrumbs.shedlock.provider.dynamodb;
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
+import com.amazonaws.services.dynamodbv2.local.shared.access.AmazonDynamoDBLocal;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.test.support.AbstractLockProviderIntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
-import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
-import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.Map;
 
 import static net.javacrumbs.shedlock.provider.dynamodb.DynamoDBLockProvider.ID;
 import static net.javacrumbs.shedlock.provider.dynamodb.DynamoDBLockProvider.LOCKED_AT;
@@ -43,47 +42,40 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <b>Note</b>: If tests fail when build in your IDE first unpack native
  * dependencies by running
  * <pre>
- * mvn verify -pl providers/dynamodb/shedlock-provider-dynamodb --also-make
+ * mvn verify -pl providers/dynamodb/shedlock-provider-dynamodb-legacy --also-make
  * </pre>
  * from project root and ensure that <code>sqlite4java.library.path</code>
  * is set to <code>./target/dependencies</code>.
  */
 public class DynamoDBLockProviderIntegrationTest extends AbstractLockProviderIntegrationTest {
-
-    // using legacy LocalDynamoDb along with AWS SDK2 DynamoDbClient as described here:
-    // https://github.com/aws/aws-sdk-java-v2/issues/982
-    private static LocalDynamoDb dynamodbFactory;
+    private static AmazonDynamoDBLocal dynamodbFactory;
 
     private static final String TABLE_NAME = "Shedlock";
-    private DynamoDbClient dynamodb;
+    private AmazonDynamoDB dynamodb;
 
     @BeforeEach
     public void createLockProvider() {
-        dynamodb = dynamodbFactory.createClient();
-        DynamoDBUtils.createLockTable(dynamodb, TABLE_NAME, ProvisionedThroughput.builder()
-            .readCapacityUnits(1L)
-            .writeCapacityUnits(1L)
-            .build());
+        dynamodb = dynamodbFactory.amazonDynamoDB();
+        DynamoDBUtils.createLockTable(dynamodb, TABLE_NAME, new ProvisionedThroughput(1L, 1L));
     }
 
     @AfterEach
     public void deleteLockTable() {
-        dynamodb.deleteTable(DeleteTableRequest.builder()
-            .tableName(TABLE_NAME)
-            .build());
+        dynamodb.deleteTable(TABLE_NAME);
     }
 
     @Override
     protected LockProvider getLockProvider() {
-        return new DynamoDBLockProvider(dynamodb, TABLE_NAME);
+        Table table = new DynamoDB(dynamodb).getTable(TABLE_NAME);
+        return new DynamoDBLockProvider(table);
     }
 
     @Override
     protected void assertUnlocked(String lockName) {
-        Map<String, AttributeValue> lockItem = getLockItem(lockName);
-        assertThat(fromIsoString(lockItem.get(LOCK_UNTIL).s())).isBeforeOrEqualTo(now());
-        assertThat(fromIsoString(lockItem.get(LOCKED_AT).s())).isBeforeOrEqualTo(now());
-        assertThat(lockItem.get(LOCKED_BY).s()).isNotEmpty();
+        Item lockItem = getLockItem(lockName);
+        assertThat(fromIsoString(lockItem.getString(LOCK_UNTIL))).isBeforeOrEqualTo(now());
+        assertThat(fromIsoString(lockItem.getString(LOCKED_AT))).isBeforeOrEqualTo(now());
+        assertThat(lockItem.getString(LOCKED_BY)).isNotEmpty();
     }
 
     private OffsetDateTime now() {
@@ -92,34 +84,31 @@ public class DynamoDBLockProviderIntegrationTest extends AbstractLockProviderInt
 
     @Override
     protected void assertLocked(String lockName) {
-        Map<String, AttributeValue> lockItem = getLockItem(lockName);
-        assertThat(fromIsoString(lockItem.get(LOCK_UNTIL).s())).isAfter(now());
-        assertThat(fromIsoString(lockItem.get(LOCKED_AT).s())).isBeforeOrEqualTo(now());
-        assertThat(lockItem.get(LOCKED_BY).s()).isNotEmpty();
+        Item lockItem = getLockItem(lockName);
+        assertThat(fromIsoString(lockItem.getString(LOCK_UNTIL))).isAfter(now());
+        assertThat(fromIsoString(lockItem.getString(LOCKED_AT))).isBeforeOrEqualTo(now());
+        assertThat(lockItem.getString(LOCKED_BY)).isNotEmpty();
     }
 
     private OffsetDateTime fromIsoString(String isoString) {
         return OffsetDateTime.parse(isoString, DateTimeFormatter.ISO_DATE_TIME);
     }
 
-    private Map<String, AttributeValue> getLockItem(String lockName) {
-        GetItemRequest request = GetItemRequest.builder()
-            .key(Collections.singletonMap(ID, AttributeValue.builder()
-                .s(lockName)
-                .build()))
-            .build();
-        GetItemResponse response = dynamodb.getItem(request);
-        return response.item();
+    private Table getLockTable() {
+        return new DynamoDB(dynamodb).getTable(TABLE_NAME);
+    }
+
+    private Item getLockItem(String lockName) {
+        return getLockTable().getItem(ID, lockName);
     }
 
     @BeforeAll
     public static void startDynamoDB() {
-        dynamodbFactory = new LocalDynamoDb();
-        dynamodbFactory.start();
+        dynamodbFactory = DynamoDBEmbedded.create();
     }
 
     @AfterAll
     public static void stopDynamoDB() {
-        dynamodbFactory.stop();
+        dynamodbFactory.shutdown();
     }
 }

--- a/providers/dynamodb/shedlock-provider-dynamodb/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBUtils.java
+++ b/providers/dynamodb/shedlock-provider-dynamodb/src/main/java/net/javacrumbs/shedlock/provider/dynamodb/DynamoDBUtils.java
@@ -15,16 +15,14 @@
  */
 package net.javacrumbs.shedlock.provider.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.document.DynamoDB;
-import com.amazonaws.services.dynamodbv2.document.Table;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ResourceInUseException;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 import static net.javacrumbs.shedlock.provider.dynamodb.DynamoDBLockProvider.ID;
 
@@ -35,27 +33,34 @@ public class DynamoDBUtils {
      * <p>
      * This method does not check if a table with the given name exists already.
      *
-     * @param dynamodb   DynamoDB to be used
+     * @param ddbClient  v2 of DynamoDBClient
      * @param tableName  table to be used
      * @param throughput AWS {@link ProvisionedThroughput throughput requirements} for the given lock setup
-     * @return           a {@link Table reference to the newly created table}
+     * @return           the table name
      *
      * @throws ResourceInUseException
      *         The operation conflicts with the resource's availability. You attempted to recreate an
      *         existing table.
      */
-    public static Table createLockTable(
-            AmazonDynamoDB dynamodb,
+    public static String createLockTable(
+            DynamoDbClient ddbClient,
             String tableName,
             ProvisionedThroughput throughput
     ) {
 
-        CreateTableRequest request = new CreateTableRequest()
-                .withTableName(tableName)
-                .withKeySchema(new KeySchemaElement(ID, KeyType.HASH))
-                .withAttributeDefinitions(new AttributeDefinition(ID, ScalarAttributeType.S))
-                .withProvisionedThroughput(throughput);
-        dynamodb.createTable(request).getTableDescription();
-        return new DynamoDB(dynamodb).getTable(tableName);
+        CreateTableRequest request = CreateTableRequest.builder()
+                .tableName(tableName)
+                .keySchema(KeySchemaElement.builder()
+                        .attributeName(ID)
+                        .keyType(KeyType.HASH)
+                        .build())
+                .attributeDefinitions(AttributeDefinition.builder()
+                        .attributeName(ID)
+                        .attributeType(ScalarAttributeType.S)
+                        .build())
+                .provisionedThroughput(throughput)
+                .build();
+        ddbClient.createTable(request);
+        return tableName;
     }
 }

--- a/providers/dynamodb/shedlock-provider-dynamodb/src/test/java/net/javacrumbs/shedlock/provider/dynamodb/LocalDynamoDb.java
+++ b/providers/dynamodb/shedlock-provider-dynamodb/src/test/java/net/javacrumbs/shedlock/provider/dynamodb/LocalDynamoDb.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
+import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Wrapper for a local DynamoDb server used in testing. Each instance of this class will find a new port to run on,
+ * so multiple instances can be safely run simultaneously. Each instance of this service uses memory as a storage medium
+ * and is thus completely ephemeral; no data will be persisted between stops and starts.
+ *
+ * LocalDynamoDb localDynamoDb = new LocalDynamoDb();
+ * localDynamoDb.start();       // Start the service running locally on host
+ * DynamoDbClient dynamoDbClient = localDynamoDb.createClient();
+ * ...      // Do your testing with the client
+ * localDynamoDb.stop();        // Stop the service and free up resources
+ *
+ * If possible it's recommended to keep a single running instance for all your tests, as it can be slow to teardown
+ * and create new servers for every test, but there have been observed problems when dropping tables between tests for
+ * this scenario, so it's best to write your tests to be resilient to tables that already have data in them.
+ */
+class LocalDynamoDb {
+    private DynamoDBProxyServer server;
+    private int port;
+
+    /**
+     * Start the local DynamoDb service and run in background
+     */
+    void start() {
+        port = getFreePort();
+        String portString = Integer.toString(port);
+
+        try {
+            server = createServer(portString);
+            server.start();
+        } catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    /**
+     * Create a standard AWS v2 SDK client pointing to the local DynamoDb instance
+     * @return A DynamoDbClient pointing to the local DynamoDb instance
+     */
+    DynamoDbClient createClient() {
+        String endpoint = String.format("http://localhost:%d", port);
+        return DynamoDbClient.builder()
+            .endpointOverride(URI.create(endpoint))
+            // The region is meaningless for local DynamoDb but required for client builder validation
+            .region(Region.US_EAST_1)
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("dummy-key", "dummy-secret")))
+            .overrideConfiguration(o -> o.addExecutionInterceptor(new VerifyUserAgentInterceptor()))
+            .build();
+    }
+
+    DynamoDbAsyncClient createAsyncClient() {
+        String endpoint = String.format("http://localhost:%d", port);
+        return DynamoDbAsyncClient.builder()
+            .endpointOverride(URI.create(endpoint))
+            .region(Region.US_EAST_1)
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("dummy-key", "dummy-secret")))
+            .overrideConfiguration(o -> o.addExecutionInterceptor(new VerifyUserAgentInterceptor()))
+            .build();
+    }
+
+    /**
+     * Stops the local DynamoDb service and frees up resources it is using.
+     */
+    void stop() {
+        try {
+            server.stop();
+        } catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    private DynamoDBProxyServer createServer(String portString) throws Exception {
+        return ServerRunner.createServerFromCommandLineArgs(
+            new String[]{
+                "-inMemory",
+                "-port", portString
+            });
+    }
+
+    private int getFreePort() {
+        try {
+            ServerSocket socket = new ServerSocket(0);
+            int port = socket.getLocalPort();
+            socket.close();
+            return port;
+        } catch (IOException ioe) {
+            throw propagate(ioe);
+        }
+    }
+
+    private static RuntimeException propagate(Exception e) {
+        if (e instanceof RuntimeException) {
+            throw (RuntimeException)e;
+        }
+        throw new RuntimeException(e);
+    }
+
+    private static class VerifyUserAgentInterceptor implements ExecutionInterceptor {
+
+        @Override
+        public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            Optional<String> headers = context.httpRequest().firstMatchingHeader("User-agent");
+            assertThat(headers).isPresent();
+//            assertThat(headers.get()).contains("hll/ddb-enh");
+        }
+    }
+
+}

--- a/providers/elasticsearch/shedlock-provider-elasticsearch/pom.xml
+++ b/providers/elasticsearch/shedlock-provider-elasticsearch/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-elasticsearch</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <properties>
         <elasticsearch.version>6.4.0</elasticsearch.version>

--- a/providers/hazelcast/shedlock-provider-hazelcast/pom.xml
+++ b/providers/hazelcast/shedlock-provider-hazelcast/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-hazelcast</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <properties>
         <hazelcast.version>3.12.6</hazelcast.version>

--- a/providers/hazelcast/shedlock-provider-hazelcast4/pom.xml
+++ b/providers/hazelcast/shedlock-provider-hazelcast4/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-hazelcast4</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/providers/jdbc/shedlock-provider-jdbc-internal/pom.xml
+++ b/providers/jdbc/shedlock-provider-jdbc-internal/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-jdbc-internal</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <description>Internal module containing JDBC related code. Please do not use directly, the API might not be
         stable.
     </description>

--- a/providers/jdbc/shedlock-provider-jdbc-template/pom.xml
+++ b/providers/jdbc/shedlock-provider-jdbc-template/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-jdbc-template</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/test/java/net/javacrumbs/shedlock/provider/jdbctemplate/HsqlJdbcTemplateLockProviderIntegrationTest.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/test/java/net/javacrumbs/shedlock/provider/jdbctemplate/HsqlJdbcTemplateLockProviderIntegrationTest.java
@@ -35,7 +35,7 @@ import static net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProv
 
 public class HsqlJdbcTemplateLockProviderIntegrationTest extends AbstractHsqlJdbcLockProviderIntegrationTest {
 
-    private static final TimeZone TIME_ZONE = TimeZone.getTimeZone("CEST");
+    private static final TimeZone TIME_ZONE = TimeZone.getDefault();
 
     @Override
     protected StorageBasedLockProvider getLockProvider() {

--- a/providers/jdbc/shedlock-provider-jdbc/pom.xml
+++ b/providers/jdbc/shedlock-provider-jdbc/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-jdbc</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/providers/jdbc/shedlock-test-support-jdbc/pom.xml
+++ b/providers/jdbc/shedlock-test-support-jdbc/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-test-support-jdbc</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/providers/mongo/shedlock-provider-mongo/pom.xml
+++ b/providers/mongo/shedlock-provider-mongo/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-mongo</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/providers/redis/shedlock-provider-redis-jedis/pom.xml
+++ b/providers/redis/shedlock-provider-redis-jedis/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-redis-jedis</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/providers/redis/shedlock-provider-redis-spring-1/pom.xml
+++ b/providers/redis/shedlock-provider-redis-spring-1/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-redis-spring-1</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/providers/redis/shedlock-provider-redis-spring/pom.xml
+++ b/providers/redis/shedlock-provider-redis-spring/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-redis-spring</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/providers/zookeeper/shedlock-provider-zookeeper-curator/pom.xml
+++ b/providers/zookeeper/shedlock-provider-zookeeper-curator/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-provider-zookeeper-curator</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <properties>
         <curator.version>4.2.0</curator.version>

--- a/shedlock-core/pom.xml
+++ b/shedlock-core/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-core</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/shedlock-test-support/pom.xml
+++ b/shedlock-test-support/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-test-support</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/spring/shedlock-spring/pom.xml
+++ b/spring/shedlock-spring/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-spring</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/spring/shedlock-springboot-test/pom.xml
+++ b/spring/shedlock-springboot-test/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-springboot-test</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/spring/shedlock-springboot22-kotlin-test/pom.xml
+++ b/spring/shedlock-springboot22-kotlin-test/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-springboot22-kotlin-test</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <properties>
         <kotlin.version>1.3.61</kotlin.version>

--- a/spring/shedlock-springboot22-sleuth-test/pom.xml
+++ b/spring/shedlock-springboot22-sleuth-test/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-springboot22-sleuth-test</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/spring/shedlock-springboot22-test/pom.xml
+++ b/spring/shedlock-springboot22-test/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-springboot22-test</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/spring/shedlock-testng-test/pom.xml
+++ b/spring/shedlock-testng-test/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
-        <version>4.7.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shedlock-testng-test</artifactId>
-    <version>4.7.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
…amodb-legacy.

Re-implemented shedlock-provider-dynamodb to use AWS SDK2 of DynamoDB client.
Changed HsqlJdbcTemplateLockProviderIntegrationTest to use TimeZone.getDefault() as it wasn't working in my timezone.
Upping version to 5.0.0-SNAPSHOT as migrating shedlock-provider-dynamodb and introduction of shedlock-provider-dynamodb-legacy are breaking changes.
Updated README.md with usage for both the newly implemented and legacy DynamoDB providers.