### PR TITLE
Add shutdown hook for ConsulLockProvider.unlockScheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,13 +530,13 @@ import net.javacrumbs.shedlock.provider.consul.ConsulLockProvider;
 
 ...
 
-@Bean
+@Bean // for micronaut please define preDestroy property @Bean(preDestroy="close")
 public ConsulLockProvider lockProvider(com.ecwid.consul.v1.ConsulClient consulClient) {
     return new ConsulLockProvider(consulClient);
 }
 ```
 
-Please, note that both Consul lock providers uses [ecwid consul-api client](https://github.com/Ecwid/consul-api), which is part of spring cloud consul integration (the `spring-cloud-starter-consul-discovery` package).
+Please, note that Consul lock provider uses [ecwid consul-api client](https://github.com/Ecwid/consul-api), which is part of spring cloud consul integration (the `spring-cloud-starter-consul-discovery` package).
 
 ### Multi-tenancy
 If you have multi-tenancy use-case you can use a lock provider similar to this one


### PR DESCRIPTION
Hi, it seems I missed the shutdown hook in my previous PR. I've added it and also added the close() method that will be automatically detected by spring.

For micronaut it's not the case as it requires an annotation for the destroy method but I don't think it's a good idea to add dependency on `javax.annotation` there so I added a commentary in the README