### PR TITLE
added arangodb lock provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ executed repeatedly. Moreover, the locks are time-based and ShedLock assumes tha
   - [CosmosDB](#cosmosdb)
   - [Cassandra](#cassandra)
   - [Consul](#consul)
+  - [ArangoDB](#arangodb)
   - [Multi-tenancy](#Multi-tenancy)
 + [Duration specification](#duration-specification)
 + [Micronaut integration](#micronaut-integration)
@@ -539,6 +540,31 @@ public ConsulLockProvider lockProvider(com.ecwid.consul.v1.ConsulClient consulCl
 ```
 
 Please, note that Consul lock provider uses [ecwid consul-api client](https://github.com/Ecwid/consul-api), which is part of spring cloud consul integration (the `spring-cloud-starter-consul-discovery` package).
+
+### ArangoDB
+Import the project
+```xml
+<dependency>
+    <groupId>net.javacrumbs.shedlock</groupId>
+    <artifactId>shedlock-provider-arangodb</artifactId>
+    <version>4.14.0</version>
+</dependency>
+```
+
+Configure:
+
+```java
+import net.javacrumbs.shedlock.provider.arangodb.ArangoLockProvider;
+
+...
+
+@Bean
+public ArangoLockProvider lockProvider(final ArangoOperations arangoTemplate) {
+    return new ArangoLockProvider(arangoTemplate.driver().db(DB_NAME));
+}
+```
+
+Please, note that ArangoDB lock provider uses ArangoDB driver v6.7, which is part of [arango-spring-data](https://github.com/arangodb/spring-data) in version 3.3.0.
 
 ### Multi-tenancy
 If you have multi-tenancy use-case you can use a lock provider similar to this one

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <module>providers/dynamodb/shedlock-provider-dynamodb2</module>
         <module>providers/cassandra/shedlock-provider-cassandra</module>
         <module>providers/consul/shedlock-provider-consul</module>
+        <module>providers/arangodb/shedlock-provider-arangodb</module>
     </modules>
 
     <properties>

--- a/providers/arangodb/shedlock-provider-arangodb/pom.xml
+++ b/providers/arangodb/shedlock-provider-arangodb/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shedlock-parent</artifactId>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <version>4.14.1-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shedlock-provider-arangodb</artifactId>
+    <version>4.14.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.arangodb</groupId>
+            <artifactId>arangodb-java-driver</artifactId>
+            <version>6.7.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.arangodb
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/providers/arangodb/shedlock-provider-arangodb/src/main/java/net/javacrumbs/shedlock/provider/arangodb/ArangoLockProvider.java
+++ b/providers/arangodb/shedlock-provider-arangodb/src/main/java/net/javacrumbs/shedlock/provider/arangodb/ArangoLockProvider.java
@@ -1,0 +1,169 @@
+package net.javacrumbs.shedlock.provider.arangodb;
+
+import com.arangodb.ArangoCollection;
+import com.arangodb.ArangoDBException;
+import com.arangodb.ArangoDatabase;
+import com.arangodb.entity.BaseDocument;
+import com.arangodb.entity.DocumentCreateEntity;
+import com.arangodb.entity.StreamTransactionEntity;
+import com.arangodb.model.DocumentCreateOptions;
+import com.arangodb.model.DocumentReadOptions;
+import com.arangodb.model.DocumentUpdateOptions;
+import com.arangodb.model.StreamTransactionOptions;
+import net.javacrumbs.shedlock.core.AbstractSimpleLock;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.support.LockException;
+import net.javacrumbs.shedlock.support.Utils;
+import net.javacrumbs.shedlock.support.annotation.NonNull;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Arango Lock Provider needs existing collection
+ * <br>
+ * Example creating a collection through init scripts (javascript)
+ * <pre>
+ * db._useDatabase("DB_NAME");
+ * db._create("COLLECTION_NAME");
+ * </pre>
+ */
+public class ArangoLockProvider implements LockProvider {
+
+    static final String LOCK_UNTIL = "lockUntil";
+    static final String LOCKED_AT = "lockedAt";
+    static final String LOCKED_BY = "lockedBy";
+    static final String COLLECTION_NAME = "shedLock";
+
+    private final String hostname;
+    private final ArangoCollection arangoCollection;
+
+
+    /**
+     * Instantiates a new Arango lock provider.
+     *
+     * @param arangoDatabase the arango database
+     */
+    public ArangoLockProvider(@NonNull ArangoDatabase arangoDatabase) {
+        this(arangoDatabase.collection(COLLECTION_NAME));
+    }
+
+    /**
+     * Instantiates a new Arango lock provider.
+     *
+     * @param arangoCollection the arango collection
+     */
+    public ArangoLockProvider(@NonNull ArangoCollection arangoCollection) {
+        this.arangoCollection = arangoCollection;
+        this.hostname = Utils.getHostname();
+    }
+
+    @Override
+    @NonNull
+    public Optional<SimpleLock> lock(@NonNull LockConfiguration lockConfiguration) {
+
+        String transactionId = null;
+
+        try {
+            /*
+                Transaction is necessary because repsert (insert with overwrite=true in arangodb)
+                is not possible with condition check (see case 2 description below)
+             */
+            StreamTransactionEntity streamTransactionEntity = arangoCollection.db().beginStreamTransaction(
+                new StreamTransactionOptions().exclusiveCollections(arangoCollection.name())
+            );
+
+            transactionId = streamTransactionEntity.getId();
+
+            /*  There are three possible situations:
+                1. The lock document does not exist yet - insert document
+                2. The lock document exists and lockUtil <= now - update document
+                3. The lock document exists and lockUtil > now - nothing to do
+             */
+            BaseDocument existingDocument = arangoCollection.getDocument(lockConfiguration.getName(),
+                BaseDocument.class, new DocumentReadOptions().streamTransactionId(transactionId));
+
+            // 1. case
+            if (existingDocument == null) {
+                BaseDocument newDocument = insertNewLock(transactionId, lockConfiguration.getName(), lockConfiguration.getLockAtMostUntil());
+                return Optional.of(new ArangoLock(arangoCollection, newDocument, lockConfiguration));
+            }
+
+            // 2. case
+            Instant lockUntil = Instant.parse(existingDocument.getAttribute(LOCK_UNTIL).toString());
+            if (lockUntil.compareTo(ClockProvider.now()) <= 0) {
+                updateLockAtMostUntil(transactionId, existingDocument, lockConfiguration.getLockAtMostUntil());
+                return Optional.of(new ArangoLock(arangoCollection, existingDocument, lockConfiguration));
+            }
+
+            // 3. case
+            return Optional.empty();
+
+        } catch (ArangoDBException e) {
+            if (transactionId != null) {
+                arangoCollection.db().abortStreamTransaction(transactionId);
+            }
+            throw new LockException("Unexpected error occured", e);
+        } finally {
+            if (transactionId != null) {
+                arangoCollection.db().commitStreamTransaction(transactionId);
+            }
+        }
+    }
+
+    private BaseDocument insertNewLock(String transactionId, String documentKey, Instant lockAtMostUntil) throws ArangoDBException {
+        BaseDocument newDocument = new BaseDocument();
+        newDocument.setKey(documentKey);
+        setDocumentAttributes(newDocument, lockAtMostUntil);
+        DocumentCreateEntity<BaseDocument> document = arangoCollection.insertDocument(newDocument,
+            new DocumentCreateOptions().streamTransactionId(transactionId).returnNew(true)
+        );
+        return document.getNew();
+    }
+
+    private void updateLockAtMostUntil(String transactionId,
+                                       BaseDocument existingDocument,
+                                       Instant lockAtMostUntil) {
+
+        setDocumentAttributes(existingDocument, lockAtMostUntil);
+        arangoCollection.updateDocument(existingDocument.getKey(), existingDocument,
+            new DocumentUpdateOptions().streamTransactionId(transactionId));
+    }
+
+    private void setDocumentAttributes(BaseDocument baseDocument, Instant lockAtMostUntil) {
+        baseDocument.addAttribute(LOCK_UNTIL, Utils.toIsoString(lockAtMostUntil));
+        baseDocument.addAttribute(LOCKED_AT, Utils.toIsoString(ClockProvider.now()));
+        baseDocument.addAttribute(LOCKED_BY, hostname);
+    }
+
+    private static final class ArangoLock extends AbstractSimpleLock {
+
+        private final ArangoCollection arangoCollection;
+        private final BaseDocument document;
+
+        public ArangoLock(final ArangoCollection arangoCollection,
+                          final BaseDocument document,
+                          final LockConfiguration lockConfiguration) {
+
+            super(lockConfiguration);
+            this.arangoCollection = arangoCollection;
+            this.document = document;
+        }
+
+        @Override
+        protected void doUnlock() {
+            try {
+                document.addAttribute(LOCK_UNTIL, Utils.toIsoString(lockConfiguration.getUnlockTime()));
+                arangoCollection.updateDocument(lockConfiguration.getName(), document);
+            } catch (ArangoDBException e) {
+                throw new LockException("Unexpected error occured", e);
+            }
+
+        }
+
+    }
+
+}

--- a/providers/arangodb/shedlock-provider-arangodb/src/test/java/net/javacrumbs/shedlock/provider/arangodb/ArangoLockProviderIntegrationTest.java
+++ b/providers/arangodb/shedlock-provider-arangodb/src/test/java/net/javacrumbs/shedlock/provider/arangodb/ArangoLockProviderIntegrationTest.java
@@ -1,0 +1,114 @@
+package net.javacrumbs.shedlock.provider.arangodb;
+
+import com.arangodb.ArangoCollection;
+import com.arangodb.ArangoDB;
+import com.arangodb.ArangoDatabase;
+import com.arangodb.entity.BaseDocument;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.test.support.AbstractLockProviderIntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.time.Instant;
+
+import static net.javacrumbs.shedlock.provider.arangodb.ArangoLockProvider.COLLECTION_NAME;
+import static net.javacrumbs.shedlock.provider.arangodb.ArangoLockProvider.LOCKED_AT;
+import static net.javacrumbs.shedlock.provider.arangodb.ArangoLockProvider.LOCKED_BY;
+import static net.javacrumbs.shedlock.provider.arangodb.ArangoLockProvider.LOCK_UNTIL;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class ArangoLockProviderIntegrationTest extends AbstractLockProviderIntegrationTest {
+
+    private static final String DB_USER = "root";
+    private static final String DB_PASSWORD = "";
+    private static final String DB_HOSTNAME = "localhost";
+    private static final int DB_PORT = 8529;
+
+    private static final String DB_NAME = "arangodb";
+
+    private static ArangoDB arango;
+    private static ArangoDatabase arangoDatabase;
+    private static ArangoCollection arangoCollection;
+
+    @BeforeAll
+    static void beforeAll() {
+
+        arango = new ArangoDB.Builder()
+            .host(DB_HOSTNAME, DB_PORT)
+            .user(DB_USER)
+            .password(DB_PASSWORD)
+            .useSsl(false)
+            .build();
+
+        if (!arango.getDatabases().contains(DB_NAME)) {
+            arango.createDatabase(DB_NAME);
+        }
+
+        arangoDatabase = arango.db(DB_NAME);
+
+        if (arangoDatabase.getCollections().stream()
+            .anyMatch(collectionEntity -> collectionEntity.getName().equals(COLLECTION_NAME))) {
+            arangoCollection = arangoDatabase.collection(COLLECTION_NAME);
+            arangoCollection.drop();
+        }
+    }
+
+    @AfterAll
+    static void afterAll() {
+        arango.db(DB_NAME).drop();
+        arango.shutdown();
+    }
+
+    @BeforeEach
+    void setUp() {
+        arangoDatabase.createCollection(COLLECTION_NAME);
+        arangoCollection = arangoDatabase.collection(COLLECTION_NAME);
+    }
+
+    @AfterEach
+    void tearDown() {
+        arangoCollection.drop();
+    }
+
+    @Override
+    protected LockProvider getLockProvider() {
+        return new ArangoLockProvider(arangoDatabase);
+    }
+
+    @Override
+    protected void assertUnlocked(String lockName) {
+        BaseDocument document = getDocument(lockName);
+        Instant instantLockedAt = Instant.parse((String) document.getAttribute(LOCKED_AT));
+        Instant instantLockUntil = Instant.parse((String) document.getAttribute(LOCK_UNTIL));
+
+        assertFalse(((String) document.getAttribute(LOCKED_BY)).isEmpty());
+        assertTrue(isBeforeOrEquals(instantLockedAt, ClockProvider.now()));
+        assertTrue(isBeforeOrEquals(instantLockUntil, ClockProvider.now()));
+    }
+
+    @Override
+    protected void assertLocked(String lockName) {
+        BaseDocument document = getDocument(lockName);
+
+        Instant instantLockedAt = Instant.parse(document.getAttribute(LOCKED_AT).toString());
+        Instant instantLockUntil = Instant.parse(document.getAttribute(LOCK_UNTIL).toString());
+
+        assertFalse(document.getAttribute(LOCKED_BY).toString().isEmpty());
+        assertTrue(isBeforeOrEquals(instantLockedAt, ClockProvider.now()));
+        assertTrue(instantLockUntil.isAfter(ClockProvider.now()));
+    }
+
+    private BaseDocument getDocument(String lockName) {
+        return arangoCollection.getDocument(lockName, BaseDocument.class);
+    }
+
+    private boolean isBeforeOrEquals(Instant instantOne, Instant instantTwo) {
+        return instantOne.compareTo(instantTwo) <= 0;
+    }
+
+}

--- a/providers/arangodb/shedlock-provider-arangodb/src/test/resources/logback.xml
+++ b/providers/arangodb/shedlock-provider-arangodb/src/test/resources/logback.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright 2009-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Added arangodb lock provider for usage of ShedLock with [ArangoDB](https://www.arangodb.com/) Documents. 

This lock provider uses a transaction because repsert (in arangodb insert with overwrite=true) does not support conditional checks (like in mongodb). 

The program was tested solely for our own use cases, which might differ from yours. To test the lock provider you can simply run a arangodb test instance as docker container.  (e.g.: `docker run -e ARANGO_NO_AUTH=1 --name arangodb -p 8529:8529 -d arangodb/arangodb:3.7.2 arangod --server.endpoint tcp://0.0.0.0:8529`)

<sup>Patrick Birkle <patrick.birkle@daimler.com>, Daimler TSS GmbH, [Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>