### PR TITLE
fix consul session leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 target/
+.classpath
 .idea
 *.iml
+.project
+.settings/
 .gradle/
 build/
+.attach_pid*
 micronaut/micronaut-test/dependency-reduced-pom.xml

--- a/providers/consul/shedlock-provider-consul/src/main/java/net/javacrumbs/shedlock/provider/consul/ConsulLockProvider.java
+++ b/providers/consul/shedlock-provider-consul/src/main/java/net/javacrumbs/shedlock/provider/consul/ConsulLockProvider.java
@@ -100,6 +100,7 @@ public class ConsulLockProvider implements LockProvider, AutoCloseable {
         if (isLockSuccessful) {
             return Optional.of(new ConsulSimpleLock(lockConfiguration, this, sessionId));
         }
+        destroy(sessionId);
         return Optional.empty();
     }
 


### PR DESCRIPTION
This fixes #340 

Sadly, the `ConsulLockProviderIntegrationTest` is flaky on my maschine. The `fuzzTestShouldPass` fails most of the time, when I run the complete test class because a single session remains on the consul. When running this particular test alone, everything is fine. I'm not quite sure what the cause of this might be. It feels like race condition, but I didn't find an obvious cause after a quick look over the `FuzzTester` code. Any idea?

The `@AfterEach public void checkSessions()` doesn't really feel great, but I didn't find another way to check this post condition for every test properly.

Additionally, I added some files to the .gitignore (mainly eclipse files) - I hope this is alright. I can revert this change if you don't want this in this PR.