### PR TITLE
[#345] Log unexpected exceptions at ERROR level

### DIFF
--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateStorageAccessor.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateStorageAccessor.java
@@ -68,7 +68,7 @@ class JdbcTemplateStorageAccessor extends AbstractStorageAccessor {
         } catch (DuplicateKeyException e) {
             return false;
         } catch (DataIntegrityViolationException | BadSqlGrammarException | UncategorizedSQLException e) {
-            logger.warn("Unexpected exception", e);
+            logger.error("Unexpected exception", e);
             return false;
         }
     }
@@ -82,7 +82,7 @@ class JdbcTemplateStorageAccessor extends AbstractStorageAccessor {
                 return updatedRows > 0;
             });
         } catch (DataIntegrityViolationException e) {
-            logger.warn("Unexpected exception", e);
+            logger.error("Unexpected exception", e);
             return false;
         }
     }


### PR DESCRIPTION
This enables conditions such as a name that is too long to result in an
error instead of a warning being emitted in logs, which can help
operators who alert on the basis of ERRORs. Closes #345.