### PR TITLE
Support for Configurable columns in Cassandra provider.

### DIFF
--- a/providers/cassandra/shedlock-provider-cassandra/src/main/java/net/javacrumbs/shedlock/provider/cassandra/CassandraLockProvider.java
+++ b/providers/cassandra/shedlock-provider-cassandra/src/main/java/net/javacrumbs/shedlock/provider/cassandra/CassandraLockProvider.java
@@ -24,4 +24,8 @@ public class CassandraLockProvider extends StorageBasedLockProvider {
     public CassandraLockProvider(@NonNull CqlSession cqlSession, @NonNull String table, @NonNull ConsistencyLevel consistencyLevel) {
         super(new CassandraStorageAccessor(cqlSession, table, consistencyLevel));
     }
+    
+    public CassandraLockProvider(@NonNull CqlSession cqlSession, @NonNull String table, @NonNull String lockNameColumn, @NonNull String lockUntilColumn, @NonNull String lockedAtColumn, @NonNull String lockedByColumn, @NonNull ConsistencyLevel consistencyLevel) {
+        super(new CassandraStorageAccessor(cqlSession, table, lockNameColumn, lockUntilColumn, lockedAtColumn, lockedByColumn, consistencyLevel));
+    }
 }

--- a/providers/cassandra/shedlock-provider-cassandra/src/main/java/net/javacrumbs/shedlock/provider/cassandra/CassandraLockProvider.java
+++ b/providers/cassandra/shedlock-provider-cassandra/src/main/java/net/javacrumbs/shedlock/provider/cassandra/CassandraLockProvider.java
@@ -1,31 +1,160 @@
 package net.javacrumbs.shedlock.provider.cassandra;
 
+import static java.util.Objects.requireNonNull;
+
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlSession;
+
 import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
 import net.javacrumbs.shedlock.support.annotation.NonNull;
 
 /**
- * Cassandra Lock Provider needs a keyspace and uses a lock table
- * <br>
+ * Cassandra Lock Provider needs a keyspace and uses a lock table <br>
  * Example creating keyspace and table
+ * 
  * <pre>
  * CREATE KEYSPACE shedlock with replication={'class':'SimpleStrategy', 'replication_factor':1} and durable_writes=true;
  * CREATE TABLE shedlock.lock (name text PRIMARY KEY, lockUntil timestamp, lockedAt timestamp, lockedBy text);
  * </pre>
  */
 public class CassandraLockProvider extends StorageBasedLockProvider {
-    static final String DEFAULT_TABLE = "lock";
+	static final String DEFAULT_TABLE = "lock";
 
-    public CassandraLockProvider(@NonNull CqlSession cqlSession) {
-        super(new CassandraStorageAccessor(cqlSession, DEFAULT_TABLE, ConsistencyLevel.QUORUM));
-    }
+	public CassandraLockProvider(@NonNull CqlSession cqlSession) {
+		super(new CassandraStorageAccessor(Configuration.builder().withCqlSession(cqlSession).withTableName(DEFAULT_TABLE).withConsistencyLevel(ConsistencyLevel.QUORUM).build()));
+	}
 
-    public CassandraLockProvider(@NonNull CqlSession cqlSession, @NonNull String table, @NonNull ConsistencyLevel consistencyLevel) {
-        super(new CassandraStorageAccessor(cqlSession, table, consistencyLevel));
-    }
-    
-    public CassandraLockProvider(@NonNull CqlSession cqlSession, @NonNull String table, @NonNull String lockNameColumn, @NonNull String lockUntilColumn, @NonNull String lockedAtColumn, @NonNull String lockedByColumn, @NonNull ConsistencyLevel consistencyLevel) {
-        super(new CassandraStorageAccessor(cqlSession, table, lockNameColumn, lockUntilColumn, lockedAtColumn, lockedByColumn, consistencyLevel));
+	public CassandraLockProvider(@NonNull CqlSession cqlSession, @NonNull String table,
+			@NonNull ConsistencyLevel consistencyLevel) {
+		super(new CassandraStorageAccessor(Configuration.builder().withCqlSession(cqlSession).withTableName(table).withConsistencyLevel(consistencyLevel).build()));
+	}
+
+	public CassandraLockProvider(@NonNull Configuration configuration) {
+		super(new CassandraStorageAccessor(configuration));
+	}
+
+	/**
+	 * @author Debajit Kumar Phukan
+	 * @description Convenience class to specify configuration 
+	 *
+	 */
+	public static final class Configuration {
+		private final String table;
+		private ColumnNames columnNames;
+	    private final CqlSession cqlSession;
+	    private final ConsistencyLevel consistencyLevel;
+		Configuration(
+				@NonNull CqlSession cqlSession, 
+				@NonNull String table, 
+				@NonNull ColumnNames columnNames,
+				@NonNull ConsistencyLevel consistencyLevel) {
+			    this.table = requireNonNull(table, "table can not be null");
+		        this.columnNames = requireNonNull(columnNames, "columnNames can not be null");
+			    this.cqlSession = requireNonNull(cqlSession, "cqlSession can not be null");
+		        this.consistencyLevel = requireNonNull(consistencyLevel, "consistencyLevel column can not be null");
+		}
+
+		public ColumnNames getColumnNames() {
+			return columnNames;
+		}
+
+		public void setColumnNames(ColumnNames columnNames) {
+			this.columnNames = columnNames;
+		}
+
+		public String getTable() {
+			return table;
+		}
+
+		public CqlSession getCqlSession() {
+			return cqlSession;
+		}
+
+		public ConsistencyLevel getConsistencyLevel() {
+			return consistencyLevel;
+		}
+		
+		public static Configuration.Builder builder() {
+            return new Configuration.Builder();
+        }
+		
+		/**
+		 * @author Debajit Kumar Phukan
+		 * @description Convenience builder class to build Configuration 
+		 *
+		 */
+		public static final class Builder {
+			private String table;
+			private ColumnNames columnNames = new ColumnNames("name", "lockUntil", "lockedAt", "lockedBy");
+		    private CqlSession cqlSession;
+		    private ConsistencyLevel consistencyLevel;
+
+	        public Builder withTableName(@NonNull String table) {
+	            this.table = table;
+	            return this;
+	        }
+	        public Builder withColumnNames(ColumnNames columnNames) {
+	            if (columnNames != null) {
+	            	this.columnNames = columnNames;	
+	            }
+	            return this;
+	        }
+	        
+	        public Builder withCqlSession(@NonNull CqlSession cqlSession) {
+	            this.cqlSession = cqlSession;
+	            return this;
+	        }
+	        public Builder withConsistencyLevel(@NonNull ConsistencyLevel consistencyLevel) {
+	            this.consistencyLevel = consistencyLevel;
+	            return this;
+	        }
+
+	        public CassandraLockProvider.Configuration build() {
+	            return new CassandraLockProvider.Configuration(cqlSession, table, columnNames, consistencyLevel);
+	        }
+	    }
+	}
+	
+	/**
+	 * @author Debajit Kumar Phukan
+	 * @description Convenience class to specify column names
+	 * 
+	 */
+	public static final class ColumnNames {
+		private static final String DEFAULT_LOCK_NAME = "name";
+	    private static final String DEFAULT_LOCK_UNTIL = "lockUntil";
+	    private static final String DEFAULT_LOCKED_AT = "lockedAt";
+	    private static final String DEFAULT_LOCKED_BY = "lockedBy";
+	    private final String lockName;
+	    private final String lockUntil;
+	    private final String lockedAt;
+	    private final String lockedBy;
+
+	    /**
+		 * @description Each column names are optional and if not specified the default column name would be considered.
+		 * 
+		 */
+        public ColumnNames(String lockNameColumn, String lockUntilColumn, String lockedAtColumn, String lockedByColumn) {
+        	this.lockName = lockNameColumn != null ? lockNameColumn : DEFAULT_LOCK_NAME;
+	        this.lockUntil = lockUntilColumn != null ? lockUntilColumn : DEFAULT_LOCK_UNTIL;
+	        this.lockedAt = lockedAtColumn != null ? lockedAtColumn : DEFAULT_LOCKED_AT;
+	        this.lockedBy = lockedByColumn != null ? lockedByColumn : DEFAULT_LOCKED_BY;
+        }
+
+		public String getLockName() {
+			return lockName;
+		}
+
+		public String getLockUntil() {
+			return lockUntil;
+		}
+
+		public String getLockedAt() {
+			return lockedAt;
+		}
+
+		public String getLockedBy() {
+			return lockedBy;
+		}
     }
 }

--- a/providers/cassandra/shedlock-provider-cassandra/src/test/java/net/javacrumbs/shedlock/provider/cassandra/CassandraLockProviderIntegrationTest.java
+++ b/providers/cassandra/shedlock-provider-cassandra/src/test/java/net/javacrumbs/shedlock/provider/cassandra/CassandraLockProviderIntegrationTest.java
@@ -3,6 +3,8 @@ package net.javacrumbs.shedlock.provider.cassandra;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
+
+import net.javacrumbs.shedlock.provider.cassandra.CassandraLockProvider.Configuration;
 import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
 import net.javacrumbs.shedlock.test.support.AbstractStorageBasedLockProviderIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
@@ -71,7 +73,7 @@ public class CassandraLockProviderIntegrationTest extends AbstractStorageBasedLo
     }
 
     private Lock findLock(String lockName) {
-        CassandraStorageAccessor cassandraStorageAccessor = new CassandraStorageAccessor(session, CassandraLockProvider.DEFAULT_TABLE, ConsistencyLevel.QUORUM);
+        CassandraStorageAccessor cassandraStorageAccessor = new CassandraStorageAccessor(Configuration.builder().withCqlSession(session).withConsistencyLevel(ConsistencyLevel.QUORUM).withTableName(CassandraLockProvider.DEFAULT_TABLE).build());
         return cassandraStorageAccessor.find(lockName).get();
     }
 


### PR DESCRIPTION
Hi Lukas,

As per our discussion in https://github.com/lukas-krecan/ShedLock/issues/357, I decided to implement the configurable column names for Cassandra provider which makes adds more flexibility to its usage. I have tested it locally and works as per expectation. But it is better if you check it once from your side as well. Please let me know if you have any queries.

**Changes:**
1. A new constructor for CassandraLockProvider is introduced which takes the parameters for "lockNameColumn", "lockUntilColumn", "lockedAtColumn" and "lockedByColumn" additionally.
2. Users can create custom Cassandra tables for shedlock and map their desired column names via the new constructor.
3. In CassandraLockProvider.java, line 28 to 30 have been newly introduced.
4. In CassandraStorageAccessor.java, line 35 to 166 contains the new changes.

Regards,
Debajit Kumar Phukan