### PR TITLE
Use LockConfigurationExtractor interface instead of implementation

### DIFF
--- a/shedlock-core/src/main/java/net/javacrumbs/shedlock/core/LockConfigurationExtractor.java
+++ b/shedlock-core/src/main/java/net/javacrumbs/shedlock/core/LockConfigurationExtractor.java
@@ -17,6 +17,7 @@ package net.javacrumbs.shedlock.core;
 
 import net.javacrumbs.shedlock.support.annotation.NonNull;
 
+import java.lang.reflect.Method;
 import java.util.Optional;
 
 /**
@@ -25,4 +26,7 @@ import java.util.Optional;
 public interface LockConfigurationExtractor {
     @NonNull
     Optional<LockConfiguration> getLockConfiguration(@NonNull Runnable task);
+
+    @NonNull
+    Optional<LockConfiguration> getLockConfiguration(@NonNull Object target, @NonNull Method method);
 }

--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/LockConfigurationExtractorConfiguration.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/LockConfigurationExtractorConfiguration.java
@@ -1,5 +1,6 @@
 package net.javacrumbs.shedlock.spring.aop;
 
+import net.javacrumbs.shedlock.core.LockConfigurationExtractor;
 import net.javacrumbs.shedlock.support.annotation.NonNull;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +19,7 @@ class LockConfigurationExtractorConfiguration extends AbstractLockConfiguration 
     private StringValueResolver resolver;
 
     @Bean
-    SpringLockConfigurationExtractor lockConfigurationExtractor() {
+    LockConfigurationExtractor lockConfigurationExtractor() {
         return new SpringLockConfigurationExtractor(defaultLockAtMostForDuration(), defaultLockAtLeastForDuration(), resolver, durationConverter);
     }
 

--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyLockConfiguration.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyLockConfiguration.java
@@ -16,6 +16,7 @@
 package net.javacrumbs.shedlock.spring.aop;
 
 import net.javacrumbs.shedlock.core.DefaultLockingTaskExecutor;
+import net.javacrumbs.shedlock.core.LockConfigurationExtractor;
 import net.javacrumbs.shedlock.core.LockProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
@@ -30,7 +31,7 @@ class MethodProxyLockConfiguration extends AbstractLockConfiguration {
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     MethodProxyScheduledLockAdvisor proxyScheduledLockAopBeanPostProcessor(
         @Lazy LockProvider lockProvider,
-        @Lazy SpringLockConfigurationExtractor lockConfigurationExtractor
+        @Lazy LockConfigurationExtractor lockConfigurationExtractor
     ) {
         MethodProxyScheduledLockAdvisor advisor = new MethodProxyScheduledLockAdvisor(
             lockConfigurationExtractor,

--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyScheduledLockAdvisor.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyScheduledLockAdvisor.java
@@ -16,6 +16,7 @@
 package net.javacrumbs.shedlock.spring.aop;
 
 import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockConfigurationExtractor;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor.TaskResult;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -37,7 +38,7 @@ class MethodProxyScheduledLockAdvisor extends AbstractPointcutAdvisor {
 
     private final Advice advice;
 
-    MethodProxyScheduledLockAdvisor(SpringLockConfigurationExtractor lockConfigurationExtractor, LockingTaskExecutor lockingTaskExecutor) {
+    MethodProxyScheduledLockAdvisor(LockConfigurationExtractor lockConfigurationExtractor, LockingTaskExecutor lockingTaskExecutor) {
         this.advice = new LockingInterceptor(lockConfigurationExtractor, lockingTaskExecutor);
     }
 
@@ -66,10 +67,10 @@ class MethodProxyScheduledLockAdvisor extends AbstractPointcutAdvisor {
     }
 
     private static class LockingInterceptor implements MethodInterceptor {
-        private final SpringLockConfigurationExtractor lockConfigurationExtractor;
+        private final LockConfigurationExtractor lockConfigurationExtractor;
         private final LockingTaskExecutor lockingTaskExecutor;
 
-        LockingInterceptor(SpringLockConfigurationExtractor lockConfigurationExtractor, LockingTaskExecutor lockingTaskExecutor) {
+        LockingInterceptor(LockConfigurationExtractor lockConfigurationExtractor, LockingTaskExecutor lockingTaskExecutor) {
             this.lockConfigurationExtractor = lockConfigurationExtractor;
             this.lockingTaskExecutor = lockingTaskExecutor;
         }

--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/SpringLockConfigurationExtractor.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/SpringLockConfigurationExtractor.java
@@ -69,7 +69,9 @@ class SpringLockConfigurationExtractor implements LockConfigurationExtractor {
         return Optional.empty();
     }
 
-    Optional<LockConfiguration> getLockConfiguration(Object target, Method method) {
+    @Override
+    @NonNull
+    public Optional<LockConfiguration> getLockConfiguration(@NonNull Object target, @NonNull Method method) {
         AnnotationData annotation = findAnnotation(target, method);
         if (shouldLock(annotation)) {
             return Optional.of(getLockConfiguration(annotation));


### PR DESCRIPTION
I bumped into an issue with ShedLock v4.19.0.
After using it in a real-life application, I got the following exception:
```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'healthEndpointGroupsBeanPostProcessor' defined in class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]: BeanPostProcessor before instantiation of bean failed; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'proxyScheduledLockAopBeanPostProcessor' defined in class path resource [net/javacrumbs/shedlock/spring/aop/MethodProxyLockConfiguration.class]: Unexpected exception during bean creation; nested exception is org.springframework.aop.framework.AopConfigException: Could not generate CGLIB subclass of class net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor: Common causes of this problem include using a final class or a non-visible class; nested exception is org.springframework.cglib.core.CodeGenerationException: java.lang.IllegalAccessError-->class net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor$$EnhancerBySpringCGLIB$$46ec4606 cannot access its superclass net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:526)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:213)
	at org.springframework.context.support.PostProcessorRegistrationDelegate.registerBeanPostProcessors(PostProcessorRegistrationDelegate.java:244)
	at org.springframework.context.support.AbstractApplicationContext.registerBeanPostProcessors(AbstractApplicationContext.java:767)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:572)
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:144)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:767)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:759)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:426)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:326)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1309)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1298)
	at xxx.xxx.xxxxx.xxxxxxxxxxx.Application.main(Application.java:29)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.boot.devtools.restart.RestartLauncher.run(RestartLauncher.java:49)
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'proxyScheduledLockAopBeanPostProcessor' defined in class path resource [net/javacrumbs/shedlock/spring/aop/MethodProxyLockConfiguration.class]: Unexpected exception during bean creation; nested exception is org.springframework.aop.framework.AopConfigException: Could not generate CGLIB subclass of class net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor: Common causes of this problem include using a final class or a non-visible class; nested exception is org.springframework.cglib.core.CodeGenerationException: java.lang.IllegalAccessError-->class net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor$$EnhancerBySpringCGLIB$$46ec4606 cannot access its superclass net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:544)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:213)
	at org.springframework.aop.framework.autoproxy.BeanFactoryAdvisorRetrievalHelper.findAdvisorBeans(BeanFactoryAdvisorRetrievalHelper.java:91)
	at org.springframework.aop.framework.autoproxy.AbstractAdvisorAutoProxyCreator.findCandidateAdvisors(AbstractAdvisorAutoProxyCreator.java:111)
	at org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator.findCandidateAdvisors(AnnotationAwareAspectJAutoProxyCreator.java:92)
	at org.springframework.aop.aspectj.autoproxy.AspectJAwareAdvisorAutoProxyCreator.shouldSkip(AspectJAwareAdvisorAutoProxyCreator.java:101)
	at org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator.postProcessBeforeInstantiation(AbstractAutoProxyCreator.java:251)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInstantiation(AbstractAutowireCapableBeanFactory.java:1144)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.resolveBeforeInstantiation(AbstractAutowireCapableBeanFactory.java:1119)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:520)
	... 20 common frames omitted
Caused by: org.springframework.aop.framework.AopConfigException: Could not generate CGLIB subclass of class net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor: Common causes of this problem include using a final class or a non-visible class; nested exception is org.springframework.cglib.core.CodeGenerationException: java.lang.IllegalAccessError-->class net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor$$EnhancerBySpringCGLIB$$46ec4606 cannot access its superclass net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor
	at org.springframework.aop.framework.CglibAopProxy.getProxy(CglibAopProxy.java:208)
	at org.springframework.aop.framework.ProxyFactory.getProxy(ProxyFactory.java:110)
	at org.springframework.context.annotation.ContextAnnotationAutowireCandidateResolver.buildLazyResolutionProxy(ContextAnnotationAutowireCandidateResolver.java:130)
	at org.springframework.context.annotation.ContextAnnotationAutowireCandidateResolver.getLazyResolutionProxyIfNecessary(ContextAnnotationAutowireCandidateResolver.java:54)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1284)
	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:887)
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:791)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:541)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1336)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1179)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:571)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:531)
	... 32 common frames omitted
Caused by: org.springframework.cglib.core.CodeGenerationException: java.lang.IllegalAccessError-->class net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor$$EnhancerBySpringCGLIB$$46ec4606 cannot access its superclass net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor
	at org.springframework.cglib.core.ReflectUtils.defineClass(ReflectUtils.java:538)
	at org.springframework.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:363)
	at org.springframework.cglib.proxy.Enhancer.generate(Enhancer.java:585)
	at org.springframework.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:110)
	at org.springframework.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:108)
	at org.springframework.cglib.core.internal.LoadingCache$2.call(LoadingCache.java:54)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.springframework.cglib.core.internal.LoadingCache.createEntry(LoadingCache.java:61)
	at org.springframework.cglib.core.internal.LoadingCache.get(LoadingCache.java:34)
	at org.springframework.cglib.core.AbstractClassGenerator$ClassLoaderData.get(AbstractClassGenerator.java:134)
	at org.springframework.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:319)
	at org.springframework.cglib.proxy.Enhancer.createHelper(Enhancer.java:572)
	at org.springframework.cglib.proxy.Enhancer.createClass(Enhancer.java:419)
	at org.springframework.aop.framework.ObjenesisCglibAopProxy.createProxyClassAndInstance(ObjenesisCglibAopProxy.java:57)
	at org.springframework.aop.framework.CglibAopProxy.getProxy(CglibAopProxy.java:205)
	... 43 common frames omitted
Caused by: java.lang.IllegalAccessError: class net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor$$EnhancerBySpringCGLIB$$46ec4606 cannot access its superclass net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.cglib.core.ReflectUtils.defineClass(ReflectUtils.java:535)
	... 57 common frames omitted
```

1. Which version do you use: 4.0.19 (Spring Boot v2.4.1, Java 1.8.0_262)
2. Which Lock Provider: shedlock-provider-hazelcast4
3. ShedLock configuration: InterceptMode.PROXY_METHOD

Because of `@Lazy` annotation on `SpringLockConfigurationExtractor` in `MethodProxyLockConfiguration.java`, Spring wants to create lazy resolution proxy for `SpringLockConfigurationExtractor` which is not working because SpringLockConfigurationExtractor is not accesible.

My solution is to use LockConfigurationExtractor interface instead of implementation.