### PR TITLE
https://github.com/lukas-krecan/ShedLock/issues/366 added provider fo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>providers/cassandra/shedlock-provider-cassandra</module>
         <module>providers/consul/shedlock-provider-consul</module>
         <module>providers/arangodb/shedlock-provider-arangodb</module>
+        <module>providers/etcd/shedlock-provider-etcd</module>
     </modules>
 
     <properties>

--- a/providers/etcd/shedlock-provider-etcd/pom.xml
+++ b/providers/etcd/shedlock-provider-etcd/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shedlock-parent</artifactId>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <version>4.19.2-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shedlock-provider-etcd</artifactId>
+
+    <properties>
+        <jetcd.version>0.5.4</jetcd.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-core</artifactId>
+            <version>${jetcd.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-test</artifactId>
+            <version>${jetcd.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.etcd
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/providers/etcd/shedlock-provider-etcd/src/main/java/net/javacrumbs/shedlock/provider/etcd/EtcdLockProvider.java
+++ b/providers/etcd/shedlock-provider-etcd/src/main/java/net/javacrumbs/shedlock/provider/etcd/EtcdLockProvider.java
@@ -35,8 +35,6 @@ import net.javacrumbs.shedlock.core.SimpleLock;
 import net.javacrumbs.shedlock.support.LockException;
 import net.javacrumbs.shedlock.support.annotation.NonNull;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
@@ -72,7 +70,7 @@ public class EtcdLockProvider implements LockProvider {
     }
 
     private static final class EtcdLock extends AbstractSimpleLock {
-        private static final BigDecimal MILLIS_IN_SECOND = BigDecimal.valueOf(1000);
+        private static final long MILLIS_IN_SECOND = 1000L;
         private final String key;
         private Long successLeaseId;
         private final EtcdTemplate etcdTemplate;
@@ -121,9 +119,7 @@ public class EtcdLockProvider implements LockProvider {
         }
 
         private long getSecondsUntil(Instant instant) {
-            return BigDecimal.valueOf(getMsUntil(instant))
-                .divide(MILLIS_IN_SECOND, RoundingMode.CEILING)
-                .longValue();
+            return (long) Math.ceil((double) getMsUntil(instant) / MILLIS_IN_SECOND);
         }
 
         private long getMsUntil(Instant instant) {

--- a/providers/etcd/shedlock-provider-etcd/src/main/java/net/javacrumbs/shedlock/provider/etcd/EtcdLockProvider.java
+++ b/providers/etcd/shedlock-provider-etcd/src/main/java/net/javacrumbs/shedlock/provider/etcd/EtcdLockProvider.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2009-2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.etcd;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.Lease;
+import io.etcd.jetcd.Txn;
+import io.etcd.jetcd.kv.TxnResponse;
+import io.etcd.jetcd.lease.LeaseGrantResponse;
+import io.etcd.jetcd.op.Cmp;
+import io.etcd.jetcd.op.CmpTarget;
+import io.etcd.jetcd.op.Op;
+import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.PutOption;
+import net.javacrumbs.shedlock.core.AbstractSimpleLock;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.support.LockException;
+import net.javacrumbs.shedlock.support.annotation.NonNull;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static net.javacrumbs.shedlock.support.Utils.getHostname;
+import static net.javacrumbs.shedlock.support.Utils.toIsoString;
+
+public class EtcdLockProvider implements LockProvider {
+
+    private static final String KEY_PREFIX = "job-lock";
+    // prepared multi-environment support
+    static final String ENV_DEFAULT = "default";
+
+    private final EtcdTemplate etcdTemplate;
+
+    public EtcdLockProvider(@NonNull Client client) {
+        this.etcdTemplate = new EtcdTemplate(client);
+    }
+
+    @Override
+    @NonNull
+    public Optional<SimpleLock> lock(@NonNull LockConfiguration lockConfiguration) {
+        String key = buildKey(lockConfiguration.getName(), ENV_DEFAULT);
+        return new EtcdLock(key, etcdTemplate, lockConfiguration).lease();
+    }
+
+    private static final class EtcdLock extends AbstractSimpleLock {
+        public static final BigDecimal MILLIS_IN_SECOND = BigDecimal.valueOf(1000);
+        private final String key;
+        private Long successLeaseId;
+        private final EtcdTemplate etcdTemplate;
+
+        private EtcdLock(String key, EtcdTemplate etcdTemplate, LockConfiguration lockConfiguration) {
+            super(lockConfiguration);
+            this.key = key;
+            this.etcdTemplate = etcdTemplate;
+        }
+
+        EtcdLock successLeaseId(Long successLeaseId) {
+            this.successLeaseId = successLeaseId;
+            return this;
+        }
+
+        Optional<SimpleLock> lease() {
+            Long leaseId = etcdTemplate.createLease(getSecondsUntil(lockConfiguration.getLockAtMostUntil()));
+
+            Optional<Long> lockSuccess = etcdTemplate.tryToLock(key, buildValue(), leaseId);
+            if (lockSuccess.isPresent()) {
+                return lockSuccess.map(this::successLeaseId);
+            } else {
+                etcdTemplate.revoke(leaseId);
+                return Optional.empty();
+            }
+        }
+
+        @Override
+        public void doUnlock() {
+            long keepLockFor = getSecondsUntil(lockConfiguration.getLockAtLeastUntil());
+
+            // lock at least until is in the past
+            if (keepLockFor <= 0) {
+                try {
+                    etcdTemplate.revoke(successLeaseId);
+                } catch (Exception e) {
+                    throw new LockException("Can not remove node", e);
+                }
+            } else {
+                Long leaseId = etcdTemplate.createLease(keepLockFor);
+
+                etcdTemplate.updateLease(key, buildValue(), leaseId);
+                this.successLeaseId = leaseId;
+            }
+        }
+
+        private long getSecondsUntil(Instant instant) {
+            return BigDecimal.valueOf(getMsUntil(instant))
+                .divide(MILLIS_IN_SECOND, RoundingMode.CEILING)
+                .longValue();
+        }
+
+        private long getMsUntil(Instant instant) {
+            return Duration.between(ClockProvider.now(), instant).toMillis();
+        }
+
+        private String buildValue() {
+            return String.format("ADDED:%s@%s", toIsoString(ClockProvider.now()), getHostname());
+        }
+
+    }
+
+    static String buildKey(String lockName, String env) {
+        return String.format("%s:%s:%s", KEY_PREFIX, env, lockName);
+    }
+
+    private static class EtcdTemplate {
+        private final KV kvClient;
+        private final Lease leaseClient;
+
+        private EtcdTemplate(Client client) {
+            this.kvClient = client.getKVClient();
+            this.leaseClient = client.getLeaseClient();
+        }
+
+        public Long createLease(long lockUntilInSeconds) {
+            CompletableFuture<LeaseGrantResponse> leaseGrantResp = leaseClient.grant(lockUntilInSeconds);
+            try {
+                return leaseGrantResp.get().getID();
+            } catch (Exception e) {
+                throw new LockException("Failed create lease", e);
+            }
+        }
+
+        public Optional<Long> tryToLock(String key, String value, Long leaseId) {
+            try {
+                ByteSequence lockKey = ByteSequence.from(key.getBytes());
+
+                PutOption putOption = PutOption.newBuilder()
+                    .withLeaseId(leaseId)
+                    .build();
+
+                GetOption getOption = GetOption.DEFAULT;
+
+                Txn txn = kvClient.txn()
+                    .If(new Cmp(lockKey, Cmp.Op.EQUAL, CmpTarget.version(0)))
+                    .Then(Op.put(lockKey, ByteSequence.from(value.getBytes()), putOption))
+                    .Else(Op.get(lockKey, getOption));
+                CompletableFuture<TxnResponse> txnRespFuture = txn.commit();
+
+                TxnResponse tr = txnRespFuture.get();
+                if (tr.isSucceeded()) {
+                    return Optional.of(leaseId);
+                }
+            } catch (Exception e) {
+                throw new LockException("Failed to set lock " + key, e);
+            }
+            return Optional.empty();
+        }
+
+        public void revoke(Long leaseId) {
+            try {
+                leaseClient.revoke(leaseId);
+            } catch (Exception e) {
+                throw new LockException("Failed to revoke lease " + leaseId, e);
+            }
+        }
+
+        public void updateLease(String key, String value, Long leaseId) {
+            ByteSequence lockKey = ByteSequence.from(key.getBytes());
+            ByteSequence lockValue = ByteSequence.from(value.getBytes());
+
+            PutOption putOption = PutOption.newBuilder()
+                .withLeaseId(leaseId)
+                .build();
+            kvClient.put(lockKey, lockValue, putOption);
+        }
+    }
+
+}

--- a/providers/etcd/shedlock-provider-etcd/src/test/java/net/javacrumbs/shedlock/provider/etcd/EtcdLockProviderIntegrationTest.java
+++ b/providers/etcd/shedlock-provider-etcd/src/test/java/net/javacrumbs/shedlock/provider/etcd/EtcdLockProviderIntegrationTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2009-2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.etcd;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.test.EtcdClusterExtension;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.test.support.AbstractLockProviderIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static java.lang.Thread.sleep;
+import static net.javacrumbs.shedlock.provider.etcd.EtcdLockProvider.ENV_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class EtcdLockProviderIntegrationTest extends AbstractLockProviderIntegrationTest {
+
+    @RegisterExtension
+    static EtcdClusterExtension etcdCluster =
+        new EtcdClusterExtension("it-cluster", 1);
+
+    private LockProvider lockProvider;
+    private KV kvClient;
+
+    @BeforeEach
+    public void createLockProvider() {
+        Client client = buildClient();
+        // the first call is very slow, so we do this warm up before the actual tests
+        warmUpLeaseClient(client);
+        kvClient = client.getKVClient();
+        lockProvider = new EtcdLockProvider(client);
+    }
+
+    private void warmUpLeaseClient(Client client) {
+        try {
+            client.getLeaseClient().grant(2).get();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    /**
+     * Modified for etcd, since its lease grants only suppport TTL in seconds
+     */
+    @Test
+    @Override
+    public void shouldTimeout() throws InterruptedException {
+        Duration lockAtMostFor = Duration.ofSeconds(1);
+        LockConfiguration configWithShortTimeout = lockConfig(LOCK_NAME1, lockAtMostFor, Duration.ZERO);
+        Optional<SimpleLock> lock1 = getLockProvider().lock(configWithShortTimeout);
+        assertThat(lock1).isNotEmpty();
+
+        sleep(3000);
+        assertUnlocked(LOCK_NAME1);
+
+        Optional<SimpleLock> lock2 = getLockProvider().lock(lockConfig(LOCK_NAME1, Duration.ofMillis(50), Duration.ZERO));
+        assertThat(lock2).isNotEmpty();
+        lock2.get().unlock();
+    }
+
+    /**
+     * Modified for etcd, since its lease grants only suppport TTL in seconds
+     */
+    @Test
+    @Override
+    public void shouldLockAtLeastFor() throws InterruptedException {
+        // Lock for LOCK_AT_LEAST_FOR - we do not expect the lock to be released before this time
+        Optional<SimpleLock> lock1 = getLockProvider().lock(lockConfig(LOCK_NAME1, LOCK_AT_LEAST_FOR.multipliedBy(2), LOCK_AT_LEAST_FOR));
+        assertThat(lock1).isNotEmpty();
+        lock1.get().unlock();
+
+        // Even though we have unlocked the lock, it will be held for some time
+        assertThat(getLockProvider().lock(lockConfig(LOCK_NAME1))).describedAs("Can not acquire lock, grace period did not pass yet").isEmpty();
+
+        // Let's wait for the lock to be automatically released
+        sleep(LOCK_AT_LEAST_FOR.toMillis() + 2000);
+
+        // Should be able to acquire now
+        Optional<SimpleLock> lock3 = getLockProvider().lock(lockConfig(LOCK_NAME1));
+        assertThat(lock3).describedAs("Can acquire the lock after grace period").isNotEmpty();
+        lock3.get().unlock();
+    }
+
+    @Override
+    protected void assertUnlocked(String lockName) {
+        ByteSequence key = ByteSequence.from(EtcdLockProvider.buildKey(lockName, ENV_DEFAULT).getBytes());
+        try {
+            sleep(500);
+            assertEquals(0, kvClient.get(key).get().getCount());
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+    @Override
+    protected void assertLocked(String lockName) {
+        ByteSequence key = ByteSequence.from(EtcdLockProvider.buildKey(lockName, ENV_DEFAULT).getBytes());
+        try {
+            assertEquals(1, kvClient.get(key).get().getCount());
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+    @Override
+    protected LockProvider getLockProvider() {
+        return lockProvider;
+    }
+
+    Client buildClient() {
+        return Client.builder().endpoints(etcdCluster.getClientEndpoints()).build();
+    }
+
+}

--- a/providers/etcd/shedlock-provider-etcd/src/test/resources/logback.xml
+++ b/providers/etcd/shedlock-provider-etcd/src/test/resources/logback.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright 2009-2021 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Implemented a provider for etcd like requested by @goudai in https://github.com/lukas-krecan/ShedLock/issues/366.

Note that etcds [leases only support TTLs in seconds,](https://etcd.io/docs/v3.4.0/dev-guide/interacting_v3/#grant-leases) therefore the integration tests needed some adjustments for this provider.