### PR TITLE
Fix for  SQLCODE=-440 on DB2

### DIFF
--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/Db2ServerTimeStatementsSource.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/Db2ServerTimeStatementsSource.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 class Db2ServerTimeStatementsSource extends SqlStatementsSource {
     private final String now = "(CURRENT TIMESTAMP - CURRENT TIMEZONE)";
-    private final String lockAtMostFor = "ADD_SECONDS(" + now + ", :lockAtMostForSeconds)";
+    private final String lockAtMostFor = "("+ now + " + :lockAtMostForSeconds SECONDS)";
 
     Db2ServerTimeStatementsSource(JdbcTemplateLockProvider.Configuration configuration) {
         super(configuration);

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/Db2ServerTimeStatementsSource.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/Db2ServerTimeStatementsSource.java
@@ -26,7 +26,7 @@ class Db2ServerTimeStatementsSource extends SqlStatementsSource {
 
     @Override
     public String getUnlockStatement() {
-        String lockAtLeastFor = "ADD_SECONDS(" + lockedAt() + ", :lockAtLeastForSeconds)";
+        String lockAtLeastFor = "(" + lockedAt() + "+ :lockAtLeastForSeconds SECONDS)";
         return "UPDATE " + tableName() + " SET " + lockUntil() + " = CASE WHEN " + lockAtLeastFor + " > " + now + " THEN " + lockAtLeastFor + " ELSE " + now + " END WHERE " + name() + " = :name AND " + lockedBy() + " = :lockedBy";
     }
 


### PR DESCRIPTION
Getting following error in DB2:
 INSERT INTO shedlock(name, lock_until, locked_at, locked_by) 
VALUES('testlockname', ADD_SECONDS(CURRENT TIMESTAMP, 10), (CURRENT TIMESTAMP - CURRENT TIMEZONE), 'testHost')
No authorized routine named "ADD_SECONDS" of type "FUNCTION" having compatible arguments was found.. SQLCODE=-440, SQLSTATE=42884, DRIVER=4.19.56

Changed to below:
 INSERT INTO shedlock(name, lock_until, locked_at, locked_by) 
VALUES('testlockname', ((CURRENT TIMESTAMP - CURRENT TIMEZONE) + 10 SECONDS), (CURRENT TIMESTAMP - CURRENT TIMEZONE), 'testHost')