### PR TITLE
adding micronaut-data lock provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ executed repeatedly. Moreover, the locks are time-based and ShedLock assumes tha
 + [Components](#components)
 + [Usage](#usage)
 + [Lock Providers](#configure-lockprovider)
+  - [Jdbc](#jdbc)
   - [JdbcTemplate](#jdbctemplate)
+  - [Micronaut Data Jdbc](#micronaut-data-jdbc)
   - [Mongo](#mongo)
   - [DynamoDB](#dynamodb)
   - [DynamoDB 2](#dynamodb-2)
@@ -134,6 +136,53 @@ it may be executed again and the results will be unpredictable (more processes w
 ### Configure LockProvider
 There are several implementations of LockProvider.
 
+#### Jdbc
+First, create lock table (**please note that `name` has to be primary key**)
+
+```sql
+# MySQL, MariaDB
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
+
+# Postgres
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until TIMESTAMP NOT NULL,
+    locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
+
+# Oracle
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL, locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
+
+# MS SQL
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until datetime2 NOT NULL,
+    locked_at datetime2 NOT NULL, locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
+
+# DB2
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL PRIMARY KEY, lock_until TIMESTAMP NOT NULL,
+    locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL);
+```
+
+Add dependency
+
+```xml
+<dependency>
+    <groupId>net.javacrumbs.shedlock</groupId>
+    <artifactId>shedlock-provider-jdbc</artifactId>
+    <version>4.13.0</version>
+</dependency>
+```
+
+Configure:
+
+```java
+import net.javacrumbs.shedlock.provider.jdbc.JdbcLockProvider;
+
+...
+@Bean
+public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcLockProvider(dataSource);
+}
+```
+
 #### JdbcTemplate
 First, create lock table (**please note that `name` has to be primary key**)
 
@@ -207,6 +256,52 @@ If you need to specify a schema, you can set it in the table name using the usua
 so the row will NOT be automatically recreated until application restart. If you need to, you can edit the row/document, risking only
 that multiple locks will be held.
 
+#### Micronaut Data Jdbc
+First, create lock table (**please note that `name` has to be primary key**)
+
+```sql
+# MySQL, MariaDB
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
+
+# Postgres
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until TIMESTAMP NOT NULL,
+    locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
+
+# Oracle
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL, locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
+
+# MS SQL
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until datetime2 NOT NULL,
+    locked_at datetime2 NOT NULL, locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
+
+# DB2
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL PRIMARY KEY, lock_until TIMESTAMP NOT NULL,
+    locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL);
+```
+
+Add dependency
+
+```xml
+<dependency>
+    <groupId>net.javacrumbs.shedlock</groupId>
+    <artifactId>shedlock-provider-micronaut-data</artifactId>
+    <version>4.13.0</version>
+</dependency>
+```
+
+Configure:
+
+```java
+import net.javacrumbs.shedlock.provider.micronautdata.MicronautDataLockProvider;
+
+...
+@Bean
+public LockProvider lockProvider(DataSource dataSource) {
+        return new MicronautDataLockProvider(dataSource);
+}
+```
 
 #### Mongo
 Import the project

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>providers/jdbc/shedlock-test-support-jdbc</module>
         <module>providers/jdbc/shedlock-provider-jdbc</module>
         <module>providers/jdbc/shedlock-provider-jdbc-template</module>
+        <module>providers/jdbc/shedlock-provider-micronaut-data</module>
         <module>providers/mongo/shedlock-provider-mongo</module>
         <module>providers/mongo/shedlock-provider-mongo-reactivestreams</module>
         <module>providers/elasticsearch/shedlock-provider-elasticsearch</module>
@@ -65,6 +66,7 @@
         <test-containers.version>1.15.2</test-containers.version>
         <kotlin.version>1.4.32</kotlin.version>
         <micronaut.version>2.4.2</micronaut.version>
+        <micronaut-data.version>2.3.1</micronaut-data.version>
         <logback.version>1.2.3</logback.version>
     </properties>
 

--- a/providers/jdbc/shedlock-provider-micronaut-data/pom.xml
+++ b/providers/jdbc/shedlock-provider-micronaut-data/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shedlock-parent</artifactId>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <version>4.13.1-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shedlock-provider-micronaut-data</artifactId>
+    <version>4.13.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-jdbc</artifactId>
+            <version>${micronaut-data.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support-jdbc</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.jdbc
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/providers/jdbc/shedlock-provider-micronaut-data/src/main/java/net/javacrumbs/shedlock/provider/micronautdata/MicronautDataLockProvider.java
+++ b/providers/jdbc/shedlock-provider-micronaut-data/src/main/java/net/javacrumbs/shedlock/provider/micronautdata/MicronautDataLockProvider.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.micronautdata;
+
+import io.micronaut.transaction.SynchronousTransactionManager;
+import io.micronaut.transaction.jdbc.DataSourceTransactionManager;
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import net.javacrumbs.shedlock.support.annotation.NonNull;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+/**
+ * Lock provided by plain JDBC, using the Micronaut Data transaction manager. It uses a table that contains lock_name and locked_until.
+ * <ol>
+ * <li>
+ * Attempts to insert a new lock record. Since lock name is a primary key, it fails if the record already exists. As an optimization,
+ * we keep in-memory track of created  lock records.
+ * </li>
+ * <li>
+ * If the insert succeeds (1 inserted row) we have the lock.
+ * </li>
+ * <li>
+ * If the insert failed due to duplicate key or we have skipped the insertion, we will try to update lock record using
+ * UPDATE tableName SET lock_until = :lockUntil WHERE name = :lockName AND lock_until &lt;= :now
+ * </li>
+ * <li>
+ * If the update succeeded (1 updated row), we have the lock. If the update failed (0 updated rows) somebody else holds the lock
+ * </li>
+ * <li>
+ * When unlocking, lock_until is set to now.
+ * </li>
+ * </ol>
+ */
+public class MicronautDataLockProvider extends StorageBasedLockProvider {
+
+    private static final String DEFAULT_TABLE_NAME = "shedlock";
+
+    public MicronautDataLockProvider(@NonNull DataSource datasource) {
+        this(new DataSourceTransactionManager(datasource), DEFAULT_TABLE_NAME);
+    }
+
+    public MicronautDataLockProvider(@NonNull DataSource datasource, @NonNull SynchronousTransactionManager<Connection> transactionManager) {
+        this(transactionManager, DEFAULT_TABLE_NAME);
+    }
+
+    public MicronautDataLockProvider(@NonNull DataSource datasource, @NonNull String tableName) {
+        this(new DataSourceTransactionManager(datasource), tableName);
+    }
+
+    public MicronautDataLockProvider(@NonNull SynchronousTransactionManager<Connection> transactionManager, @NonNull String tableName) {
+        super(new MicronautDataStorageAccessor(transactionManager, tableName));
+    }
+}

--- a/providers/jdbc/shedlock-provider-micronaut-data/src/main/java/net/javacrumbs/shedlock/provider/micronautdata/MicronautDataStorageAccessor.java
+++ b/providers/jdbc/shedlock-provider-micronaut-data/src/main/java/net/javacrumbs/shedlock/provider/micronautdata/MicronautDataStorageAccessor.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.micronautdata;
+
+import io.micronaut.transaction.SynchronousTransactionManager;
+import io.micronaut.transaction.TransactionDefinition;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.support.AbstractStorageAccessor;
+import net.javacrumbs.shedlock.support.LockException;
+import net.javacrumbs.shedlock.support.annotation.NonNull;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Timestamp;
+
+import static java.util.Objects.requireNonNull;
+
+class MicronautDataStorageAccessor extends AbstractStorageAccessor {
+    private final SynchronousTransactionManager<Connection> transactionManager;
+    private final String tableName;
+
+    private final TransactionDefinition.Propagation propagation = TransactionDefinition.Propagation.REQUIRES_NEW;
+
+    MicronautDataStorageAccessor(@NonNull SynchronousTransactionManager<Connection> transactionManager, @NonNull String tableName) {
+        this.transactionManager = transactionManager;
+        this.tableName = requireNonNull(tableName, "tableName can not be null");
+    }
+
+    @Override
+    public boolean insertRecord(@NonNull LockConfiguration lockConfiguration) {
+        // Try to insert if the record does not exists (not optimal, but the simplest platform agnostic way)
+        String sql = "INSERT INTO " + tableName + "(name, lock_until, locked_at, locked_by) VALUES(?, ?, ?, ?)";
+            return transactionManager.execute(TransactionDefinition.of(propagation), status -> {
+                try (PreparedStatement statement = status.getConnection().prepareStatement(sql)) {
+                    statement.setString(1, lockConfiguration.getName());
+                    statement.setTimestamp(2, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
+                    statement.setTimestamp(3, Timestamp.from(ClockProvider.now()));
+                    statement.setString(4, getHostname());
+                    return statement.executeUpdate() > 0;
+                } catch (SQLException e) {
+                    handleInsertionException(sql, e);
+                    return false;
+                }
+            });
+    }
+
+    @Override
+    public boolean updateRecord(@NonNull LockConfiguration lockConfiguration) {
+        String sql = "UPDATE " + tableName + " SET lock_until = ?, locked_at = ?, locked_by = ? WHERE name = ? AND lock_until <= ?";
+            return transactionManager.execute(TransactionDefinition.of(propagation), status -> {
+                try (PreparedStatement statement = status.getConnection().prepareStatement(sql)) {
+                    Timestamp now = Timestamp.from(ClockProvider.now());
+                    statement.setTimestamp(1, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
+                    statement.setTimestamp(2, now);
+                    statement.setString(3, getHostname());
+                    statement.setString(4, lockConfiguration.getName());
+                    statement.setTimestamp(5, now);
+                    return statement.executeUpdate() > 0;
+                } catch (SQLException e) {
+                    handleInsertionException(sql, e);
+                    return false;
+                }
+            });
+    }
+
+    @Override
+    public boolean extend(@NonNull LockConfiguration lockConfiguration) {
+        String sql = "UPDATE " + tableName + " SET lock_until = ? WHERE name = ? AND locked_by = ? AND lock_until > ? ";
+
+        logger.debug("Extending lock={} until={}", lockConfiguration.getName(), lockConfiguration.getLockAtMostUntil());
+
+            return transactionManager.execute(TransactionDefinition.of(propagation), status -> {
+                try (PreparedStatement statement = status.getConnection().prepareStatement(sql)) {
+                    statement.setTimestamp(1, Timestamp.from(lockConfiguration.getLockAtMostUntil()));
+                    statement.setString(2, lockConfiguration.getName());
+                    statement.setString(3, getHostname());
+                    statement.setTimestamp(4, Timestamp.from(ClockProvider.now()));
+                    return statement.executeUpdate() > 0;
+                } catch (SQLException e) {
+                    handleInsertionException(sql, e);
+                    return false;
+                }
+            });
+    }
+
+    @Override
+    public void unlock(@NonNull LockConfiguration lockConfiguration) {
+        String sql = "UPDATE " + tableName + " SET lock_until = ? WHERE name = ?";
+            transactionManager.execute(TransactionDefinition.of(propagation), status -> {
+                try (PreparedStatement statement = status.getConnection().prepareStatement(sql)) {
+                    statement.setTimestamp(1, Timestamp.from(lockConfiguration.getUnlockTime()));
+                    statement.setString(2, lockConfiguration.getName());
+                    statement.executeUpdate();
+                } catch (SQLException e) {
+                    handleInsertionException(sql, e);
+                    return false;
+                }
+                return null;
+            });
+    }
+
+    void handleInsertionException(String sql, SQLException e) {
+        if (e instanceof SQLIntegrityConstraintViolationException) {
+            // lock record already exists
+        } else {
+            // can not throw exception here, some drivers (Postgres) do not throw SQLIntegrityConstraintViolationException on duplicate key
+            // we will try update in the next step, su if there is another problem, an exception will be thrown there
+            logger.debug("Exception thrown when inserting record", e);
+        }
+    }
+
+    void handleUpdateException(String sql, SQLException e) {
+        throw new LockException("Unexpected exception when locking", e);
+    }
+
+    void handleUnlockException(String sql, SQLException e) {
+        throw new LockException("Unexpected exception when unlocking", e);
+    }
+}

--- a/providers/jdbc/shedlock-provider-micronaut-data/src/test/java/net/javacrumbs/shedlock/provider/micronautdata/HsqlJdbcLockProviderIntegrationTest.java
+++ b/providers/jdbc/shedlock-provider-micronaut-data/src/test/java/net/javacrumbs/shedlock/provider/micronautdata/HsqlJdbcLockProviderIntegrationTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.micronautdata;
+
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import net.javacrumbs.shedlock.test.support.jdbc.AbstractJdbcLockProviderIntegrationTest;
+import net.javacrumbs.shedlock.test.support.jdbc.DbConfig;
+import net.javacrumbs.shedlock.test.support.jdbc.HsqlConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class HsqlJdbcLockProviderIntegrationTest extends AbstractJdbcLockProviderIntegrationTest {
+    private static final HsqlConfig dbConfig = new HsqlConfig();
+
+    @BeforeAll
+    public static void startDb() {
+        dbConfig.startDb();
+    }
+
+    @AfterAll
+    public static void shutDownDb() {
+        dbConfig.shutdownDb();
+    }
+
+    @Override
+    protected DbConfig getDbConfig() {
+        return dbConfig;
+    }
+
+    @Override
+    protected boolean useDbTime() {
+        return false;
+    }
+
+    @Override
+    protected StorageBasedLockProvider getLockProvider() {
+        return new MicronautDataLockProvider(testUtils.getDatasource());
+    }
+}

--- a/providers/jdbc/shedlock-provider-micronaut-data/src/test/java/net/javacrumbs/shedlock/provider/micronautdata/MySqlJdbcLockProviderIntegrationTest.java
+++ b/providers/jdbc/shedlock-provider-micronaut-data/src/test/java/net/javacrumbs/shedlock/provider/micronautdata/MySqlJdbcLockProviderIntegrationTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.micronautdata;
+
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import net.javacrumbs.shedlock.test.support.jdbc.AbstractJdbcLockProviderIntegrationTest;
+import net.javacrumbs.shedlock.test.support.jdbc.DbConfig;
+import net.javacrumbs.shedlock.test.support.jdbc.MySqlConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class MySqlJdbcLockProviderIntegrationTest extends AbstractJdbcLockProviderIntegrationTest {
+    private static final MySqlConfig dbConfig = new MySqlConfig();
+
+    @BeforeAll
+    public static void startDb() {
+        dbConfig.startDb();
+    }
+
+    @AfterAll
+    public static void shutDownDb() {
+        dbConfig.shutdownDb();
+    }
+
+    @Override
+    protected DbConfig getDbConfig() {
+        return dbConfig;
+    }
+
+    @Override
+    protected boolean useDbTime() {
+        return false;
+    }
+
+    @Override
+    protected StorageBasedLockProvider getLockProvider() {
+        return new MicronautDataLockProvider(testUtils.getDatasource());
+    }
+}

--- a/providers/jdbc/shedlock-provider-micronaut-data/src/test/java/net/javacrumbs/shedlock/provider/micronautdata/PostgresJdbcLockProviderIntegrationTest.java
+++ b/providers/jdbc/shedlock-provider-micronaut-data/src/test/java/net/javacrumbs/shedlock/provider/micronautdata/PostgresJdbcLockProviderIntegrationTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.micronautdata;
+
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import net.javacrumbs.shedlock.test.support.jdbc.AbstractJdbcLockProviderIntegrationTest;
+import net.javacrumbs.shedlock.test.support.jdbc.DbConfig;
+import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class PostgresJdbcLockProviderIntegrationTest extends AbstractJdbcLockProviderIntegrationTest {
+    private static final PostgresConfig dbConfig = new PostgresConfig();
+
+    @BeforeAll
+    public static void startDb() {
+        dbConfig.startDb();
+    }
+
+    @AfterAll
+    public static void shutdownDb() {
+        dbConfig.shutdownDb();
+    }
+
+    @Override
+    protected DbConfig getDbConfig() {
+        return dbConfig;
+    }
+
+    @Override
+    protected boolean useDbTime() {
+        return false;
+    }
+
+    @Override
+    protected StorageBasedLockProvider getLockProvider() {
+        return new MicronautDataLockProvider(testUtils.getDatasource());
+    }
+}

--- a/providers/jdbc/shedlock-provider-micronaut-data/src/test/resources/logback-test.xml
+++ b/providers/jdbc/shedlock-provider-micronaut-data/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.zaxxer.hikari.HikariDataSource" level="WARN" />
+    <!-- Do not log errors from `shouldNotFailIfKeyNameTooLong` tests -->
+    <logger name="net.javacrumbs.shedlock.provider.micronautdata.MicronautDataStorageAccessor" level="ERROR" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
This is needed when using https://github.com/micronaut-projects/micronaut-data for sql operations, as connections become automatically transaction aware.