### PR TITLE
CAS Consistency Granularity

### DIFF
--- a/providers/hazelcast/shedlock-provider-hazelcast/src/test/java/net/javacrumbs/shedlock/provider/hazelcast/HazelcastLockProviderClusterTest.java
+++ b/providers/hazelcast/shedlock-provider-hazelcast/src/test/java/net/javacrumbs/shedlock/provider/hazelcast/HazelcastLockProviderClusterTest.java
@@ -37,9 +37,9 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class HazelcastLockProviderClusterTest {
 
-    private static final String LOCK_NAME_1 = UUID.randomUUID().toString();
+    private final String LOCK_NAME_1 = UUID.randomUUID().toString();
 
-    private static final String LOCK_NAME_2 = UUID.randomUUID().toString();
+    private final String LOCK_NAME_2 = UUID.randomUUID().toString();
 
     private static HazelcastLockProvider lockProvider1;
 

--- a/providers/hazelcast/shedlock-provider-hazelcast4/src/test/java/net/javacrumbs/shedlock/provider/hazelcast4/HazelcastLockProviderClusterTest.java
+++ b/providers/hazelcast/shedlock-provider-hazelcast4/src/test/java/net/javacrumbs/shedlock/provider/hazelcast4/HazelcastLockProviderClusterTest.java
@@ -37,9 +37,9 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class HazelcastLockProviderClusterTest {
 
-    private static final String LOCK_NAME_1 = UUID.randomUUID().toString();
+    private final String LOCK_NAME_1 = UUID.randomUUID().toString();
 
-    private static final String LOCK_NAME_2 = UUID.randomUUID().toString();
+    private final String LOCK_NAME_2 = UUID.randomUUID().toString();
 
     private static HazelcastLockProvider lockProvider1;
 


### PR DESCRIPTION
Hi @lukas-krecan-lt,
I hope you remember me for my contributions for shedlock 4.19.0 release. I have recently seen a flaw in the current shedlock implementation and thus, decided to put a small implementation to make it more flexible for use. 

**Overview:** 
CAS (Compare And Set) or Lightweight transactions in Cassandra either go with SERIAL (Default) or LOCAL_SERIAL consistency level. SERIAL for multi data center and LOCAL_SERIAL for local data center. Shedlock internally uses lightweight transactions to guarantee the atomicity of the locking operations as shown in "Example 1".  CAS operations induce very high latency and high "WRITE TIMEOUTS" if the consistency is SERIAL in a multi datacenter set up. I am seeing this issue live in our production environment and when I thought to reduce the consistency from SERIAL to LOCAL_SERIAL, I couldn't find any option available in shedlock. Thus, please verify my changes and if you find all OK, please merge it as soon as possible so that I can apply this change in our production environment and let you know the outcome.

**What Was Implemented ?** 
I basically implemented a configuration which will allow the developers to have more control over the CONSISTENCY for CAS operations.

**How Does It Benefit ?**
If WRITE TIMEOUTS are observed due to shedlock defaulted with SERIAL CONSISTENCY level in a multi datacenter set up. This setting will help them set another CONSISTENCY level to mitigate the WRITE TIMEOUT issue.

**Example 1:**
private boolean updateUntil(String name, Instant until) {
        return execute(QueryBuilder.update(keyspace, table)
            .setColumn(lockUntil, literal(until))
            .whereColumn(lockName).isEqualTo(literal(name))
            .ifColumn(lockUntil).isGreaterThanOrEqualTo(literal(ClockProvider.now()))   -> CAS operation
            .ifColumn(lockedBy).isEqualTo(literal(hostname)) -> CAS operation
            .build());
    }