### PR TITLE
R2dbc provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
         <module>providers/jdbc/shedlock-provider-jdbc</module>
         <module>providers/jdbc/shedlock-provider-jdbc-template</module>
         <module>providers/jdbc/shedlock-provider-jdbc-micronaut</module>
+        <module>providers/r2dbc/shedlock-provider-r2dbc-internal</module>
+        <module>providers/r2dbc/shedlock-provider-r2dbc</module>
         <module>providers/mongo/shedlock-provider-mongo</module>
         <module>providers/mongo/shedlock-provider-mongo-reactivestreams</module>
         <module>providers/neo4j/shedlock-provider-neo4j</module>

--- a/providers/r2dbc/shedlock-provider-r2dbc-internal/pom.xml
+++ b/providers/r2dbc/shedlock-provider-r2dbc-internal/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <artifactId>shedlock-parent</artifactId>
+        <version>4.28.1-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>shedlock-provider-r2dbc-internal</artifactId>
+    <version>4.28.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-spi</artifactId>
+            <version>0.8.5.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.4.10</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.r2dbc.internal
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/providers/r2dbc/shedlock-provider-r2dbc-internal/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/internal/AbstractR2dbcStorageAccessor.java
+++ b/providers/r2dbc/shedlock-provider-r2dbc-internal/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/internal/AbstractR2dbcStorageAccessor.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.r2dbc.internal;
+
+import io.r2dbc.spi.R2dbcDataIntegrityViolationException;
+import io.r2dbc.spi.Statement;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.support.AbstractStorageAccessor;
+import net.javacrumbs.shedlock.support.LockException;
+import net.javacrumbs.shedlock.support.annotation.NonNull;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Internal class, please do not use.
+ */
+public abstract class AbstractR2dbcStorageAccessor extends AbstractStorageAccessor {
+    private final String tableName;
+
+    public AbstractR2dbcStorageAccessor(@NonNull String tableName) {
+        this.tableName = requireNonNull(tableName, "tableName can not be null");
+    }
+
+    @Override
+    public boolean insertRecord(@NonNull LockConfiguration lockConfiguration) {
+        return Boolean.TRUE.equals(Mono.from(insertRecordReactive(lockConfiguration)).block());
+    }
+
+    @Override
+    public boolean updateRecord(@NonNull LockConfiguration lockConfiguration) {
+        return Boolean.TRUE.equals(Mono.from(updateRecordReactive(lockConfiguration)).block());
+    }
+
+    @Override
+    public boolean extend(@NonNull LockConfiguration lockConfiguration) {
+        return Boolean.TRUE.equals(Mono.from(extendReactive(lockConfiguration)).block());
+    }
+
+    @Override
+    public void unlock(@NonNull LockConfiguration lockConfiguration) {
+        Mono.from(unlockReactive(lockConfiguration)).block();
+    }
+
+    public Publisher<Boolean> insertRecordReactive(@NonNull LockConfiguration lockConfiguration) {
+        // Try to insert if the record does not exists (not optimal, but the simplest platform agnostic way)
+        String sql = "INSERT INTO " + tableName + "(name, lock_until, locked_at, locked_by) VALUES($1, $2, $3, $4)";
+        return executeCommand(sql, statement -> {
+            statement.bind(0, lockConfiguration.getName());
+            statement.bind(1, lockConfiguration.getLockAtMostUntil());
+            statement.bind(2, ClockProvider.now());
+            statement.bind(3, getHostname());
+            return Mono.from(statement.execute()).flatMap(it -> Mono.from(it.getRowsUpdated())).map(it -> it > 0);
+        }, this::handleInsertionException);
+    }
+
+    public Publisher<Boolean> updateRecordReactive(@NonNull LockConfiguration lockConfiguration) {
+        String sql = "UPDATE " + tableName + " SET lock_until = $1, locked_at = $2, locked_by = $3 WHERE name = $4 AND lock_until <= $5";
+        return executeCommand(sql, statement -> {
+            Instant now = ClockProvider.now();
+            statement.bind(0, lockConfiguration.getLockAtMostUntil());
+            statement.bind(1, now);
+            statement.bind(2, getHostname());
+            statement.bind(3, lockConfiguration.getName());
+            statement.bind(4, now);
+            return Mono.from(statement.execute()).flatMap(it -> Mono.from(it.getRowsUpdated())).map(it -> it > 0);
+        }, this::handleUpdateException);
+    }
+
+    public Publisher<Boolean> extendReactive(@NonNull LockConfiguration lockConfiguration) {
+        String sql = "UPDATE " + tableName + " SET lock_until = $1 WHERE name = $2 AND locked_by = $3 AND lock_until > $4 ";
+
+        logger.debug("Extending lock={} until={}", lockConfiguration.getName(), lockConfiguration.getLockAtMostUntil());
+
+        return executeCommand(sql, statement -> {
+            statement.bind(0, lockConfiguration.getLockAtMostUntil());
+            statement.bind(1, lockConfiguration.getName());
+            statement.bind(2, getHostname());
+            statement.bind(3, ClockProvider.now());
+            return Mono.from(statement.execute()).flatMap(it -> Mono.from(it.getRowsUpdated())).map(it -> it > 0);
+        }, this::handleUnlockException);
+    }
+
+    public Publisher<Void> unlockReactive(@NonNull LockConfiguration lockConfiguration) {
+        String sql = "UPDATE " + tableName + " SET lock_until = $1 WHERE name = $2";
+        return executeCommand(sql, statement -> {
+            statement.bind(0, lockConfiguration.getUnlockTime());
+            statement.bind(1, lockConfiguration.getName());
+            return Mono.from(statement.execute()).flatMap(it -> Mono.from(it.getRowsUpdated())).then();
+        }, (s, t) -> handleUnlockException(s, t).then());
+    }
+
+    protected abstract <T> Mono<T> executeCommand(
+        String sql,
+        Function<Statement, Mono<T>> body,
+        BiFunction<String, Throwable, Mono<T>> exceptionHandler
+    );
+
+    Mono<Boolean> handleInsertionException(String sql, Throwable e) {
+        if (e instanceof R2dbcDataIntegrityViolationException) {
+            // lock record already exists
+        } else {
+            // can not throw exception here, some drivers (Postgres) do not throw SQLIntegrityConstraintViolationException on duplicate key
+            // we will try update in the next step, su if there is another problem, an exception will be thrown there
+            logger.debug("Exception thrown when inserting record", e);
+        }
+        return Mono.just(false);
+    }
+
+    Mono<Boolean> handleUpdateException(String sql, Throwable e) {
+        return Mono.error(new LockException("Unexpected exception when locking", e));
+    }
+
+    Mono<Boolean> handleUnlockException(String sql, Throwable e) {
+        return Mono.error(new LockException("Unexpected exception when unlocking", e));
+    }
+}

--- a/providers/r2dbc/shedlock-provider-r2dbc/pom.xml
+++ b/providers/r2dbc/shedlock-provider-r2dbc/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <artifactId>shedlock-parent</artifactId>
+        <version>4.28.1-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>shedlock-provider-r2dbc</artifactId>
+    <version>4.28.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-provider-r2dbc-internal</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support-jdbc</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-postgresql</artifactId>
+            <version>0.8.8.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.r2dbc
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/providers/r2dbc/shedlock-provider-r2dbc/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/R2dbcLockProvider.java
+++ b/providers/r2dbc/shedlock-provider-r2dbc/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/R2dbcLockProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.r2dbc;
+
+import io.r2dbc.spi.ConnectionFactory;
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import net.javacrumbs.shedlock.support.annotation.NonNull;
+
+/**
+ * Lock provided by plain R2DBC SPI. It uses a table that contains lock_name and locked_until.
+ * <ol>
+ * <li>
+ * Attempts to insert a new lock record. Since lock name is a primary key, it fails if the record already exists. As an optimization,
+ * we keep in-memory track of created  lock records.
+ * </li>
+ * <li>
+ * If the insert succeeds (1 inserted row) we have the lock.
+ * </li>
+ * <li>
+ * If the insert failed due to duplicate key or we have skipped the insertion, we will try to update lock record using
+ * UPDATE tableName SET lock_until = :lockUntil WHERE name = :lockName AND lock_until &lt;= :now
+ * </li>
+ * <li>
+ * If the update succeeded (1 updated row), we have the lock. If the update failed (0 updated rows) somebody else holds the lock
+ * </li>
+ * <li>
+ * When unlocking, lock_until is set to now.
+ * </li>
+ * </ol>
+ */
+public class R2dbcLockProvider extends StorageBasedLockProvider {
+    public R2dbcLockProvider(@NonNull ConnectionFactory connectionFactory) {
+        this(connectionFactory, "shedlock");
+    }
+
+    public R2dbcLockProvider(@NonNull ConnectionFactory connectionFactory, @NonNull String tableName) {
+        super(new R2dbcStorageAccessor(connectionFactory, tableName));
+    }
+}

--- a/providers/r2dbc/shedlock-provider-r2dbc/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/R2dbcStorageAccessor.java
+++ b/providers/r2dbc/shedlock-provider-r2dbc/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/R2dbcStorageAccessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.r2dbc;
+
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Statement;
+import net.javacrumbs.shedlock.provider.r2dbc.internal.AbstractR2dbcStorageAccessor;
+import net.javacrumbs.shedlock.support.annotation.NonNull;
+import reactor.core.publisher.Mono;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+class R2dbcStorageAccessor extends AbstractR2dbcStorageAccessor {
+    private final ConnectionFactory connectionFactory;
+
+    R2dbcStorageAccessor(@NonNull ConnectionFactory connectionFactory, @NonNull String tableName) {
+        super(tableName);
+        this.connectionFactory = requireNonNull(connectionFactory, "dataSource can not be null");
+    }
+
+    @Override
+    protected <T> Mono<T> executeCommand(
+        String sql,
+        Function<Statement, Mono<T>> body,
+        BiFunction<String, Throwable, Mono<T>> exceptionHandler
+    ) {
+        return Mono.usingWhen(
+            Mono.from(connectionFactory.create()).doOnNext(it -> it.setAutoCommit(true)),
+            conn -> body.apply(conn.createStatement(sql)).onErrorResume(throwable -> exceptionHandler.apply(sql, throwable)),
+            Connection::close,
+            (connection, throwable) -> exceptionHandler.apply(sql, throwable),
+            connection -> Mono.empty()
+        );
+    }
+}

--- a/providers/r2dbc/shedlock-provider-r2dbc/src/test/java/net/javacrumbs/shedlock/provider/r2dbc/AbstractR2dbcTest.java
+++ b/providers/r2dbc/shedlock-provider-r2dbc/src/test/java/net/javacrumbs/shedlock/provider/r2dbc/AbstractR2dbcTest.java
@@ -1,0 +1,55 @@
+package net.javacrumbs.shedlock.provider.r2dbc;
+
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import net.javacrumbs.shedlock.test.support.jdbc.AbstractJdbcLockProviderIntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+
+import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
+import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractR2dbcTest extends AbstractJdbcLockProviderIntegrationTest {
+
+    private ConnectionFactory connectionFactory;
+
+    @BeforeAll
+    public void startDb() throws IOException {
+        getDbConfig().startDb();
+    }
+
+    @AfterAll
+    public void shutDownDb() {
+        getDbConfig().shutdownDb();
+    }
+
+    @Override
+    protected boolean useDbTime() {
+        return false;
+    }
+
+    @Override
+    protected StorageBasedLockProvider getLockProvider() {
+        return new R2dbcLockProvider(connectionFactory());
+    }
+
+    protected ConnectionFactory connectionFactory() {
+        if (connectionFactory == null) {
+            connectionFactory = ConnectionFactories.get(
+                ConnectionFactoryOptions
+                    .parse(getDbConfig().getJdbcUrl().replace("jdbc", "r2dbc"))
+                    .mutate()
+                    .option(USER, getDbConfig().getUsername())
+                    .option(PASSWORD, getDbConfig().getPassword())
+                    .build()
+            );
+        }
+        return connectionFactory;
+    }
+}

--- a/providers/r2dbc/shedlock-provider-r2dbc/src/test/java/net/javacrumbs/shedlock/provider/r2dbc/PostgresR2dbcLockProviderIntegrationTest.java
+++ b/providers/r2dbc/shedlock-provider-r2dbc/src/test/java/net/javacrumbs/shedlock/provider/r2dbc/PostgresR2dbcLockProviderIntegrationTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.shedlock.provider.r2dbc;
+
+import net.javacrumbs.shedlock.test.support.jdbc.DbConfig;
+import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig;
+
+public class PostgresR2dbcLockProviderIntegrationTest extends AbstractR2dbcTest {
+    private static final PostgresConfig dbConfig = new PostgresConfig();
+
+    @Override
+    protected DbConfig getDbConfig() {
+        return dbConfig;
+    }
+}


### PR DESCRIPTION
Draft for #700.
Also, I think it makes sense to provide an alternative reactive core API and implement it for providers which use reactive API (such as Lettuce, Redisson, Mongo, Cassandra). I might try to do it if it's ok for you from an API design perspective.