### PR TITLE
README updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Now we need to integrate the library with Spring. In order to enable schedule lo
 ```java
 @Configuration
 @EnableScheduling
-@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
 class MySpringConfiguration {
     ...
 }


### PR DESCRIPTION
@EnableSchedulerLock(defaultLockAtMostFor = "10m") makes an error as below
```
Caused by: java.time.format.DateTimeParseException: Text cannot be parsed to a Duration
```
So changed it to conform to the format.