### PR TITLE
Allow HazelcastLockProvider to reconnect to the client if the connect…

### DIFF
--- a/providers/hazelcast/shedlock-provider-hazelcast4/pom.xml
+++ b/providers/hazelcast/shedlock-provider-hazelcast4/pom.xml
@@ -30,6 +30,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/providers/hazelcast/shedlock-provider-hazelcast4/src/test/java/net/javacrumbs/shedlock/provider/hazelcast4/HazelcastLockProviderRecoveryTest.java
+++ b/providers/hazelcast/shedlock-provider-hazelcast4/src/test/java/net/javacrumbs/shedlock/provider/hazelcast4/HazelcastLockProviderRecoveryTest.java
@@ -1,0 +1,50 @@
+package net.javacrumbs.shedlock.provider.hazelcast4;
+
+import com.hazelcast.client.HazelcastClientNotActiveException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static net.javacrumbs.shedlock.provider.hazelcast4.HazelcastLockProvider.LOCK_STORE_KEY_DEFAULT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class HazelcastLockProviderRecoveryTest {
+    @Mock
+    private Supplier<HazelcastInstance> instanceSupplier;
+
+    @Mock
+    private IMap<Object, Object> map;
+
+    @Mock
+    private HazelcastInstance instance;
+
+    @Test
+    void shouldRecoverFromBrokenClientConnection() {
+        when(instanceSupplier.get()).thenReturn(instance);
+        when(instance.getMap(LOCK_STORE_KEY_DEFAULT))
+            .thenThrow(new HazelcastClientNotActiveException())
+            .thenReturn(map);
+        HazelcastLockProvider lockProvider = new HazelcastLockProvider(instanceSupplier);
+
+        Optional<SimpleLock> result = lockProvider.lock(lockConfig());
+
+        assertThat(result.isPresent()).isTrue();
+    }
+
+    protected static LockConfiguration lockConfig() {
+        return new LockConfiguration(ClockProvider.now(), HazelcastLockProvider.LOCK_STORE_KEY_DEFAULT, Duration.of(5, MINUTES), Duration.ZERO);
+    }
+}


### PR DESCRIPTION
Let clients provide a `Supplier`, which `HazelcastLockProvider` can use to refresh the connection to Hazelcast in the event that the connection dies.