### PR TITLE
Support ReactiveRedisLockProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ executed repeatedly. Moreover, the locks are time-based and ShedLock assumes tha
   - [DynamoDB 2](#dynamodb-2)
   - [ZooKeeper (using Curator)](#zookeeper-using-curator)
   - [Redis (using Spring RedisConnectionFactory)](#redis-using-spring-redisconnectionfactory)
+  - [Redis (using Spring ReactiveRedisConnectionFactory)](#redis-using-spring-reactiveredisconnectionfactory)
   - [Redis (using Jedis)](#redis-using-jedis)
   - [Hazelcast](#hazelcast)
   - [Couchbase](#couchbase)
@@ -431,6 +432,30 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 @Bean
 public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
     return new RedisLockProvider(connectionFactory, ENV);
+}
+```
+
+#### Redis (using Spring ReactiveRedisConnectionFactory)
+Import
+```xml
+<dependency>
+    <groupId>net.javacrumbs.shedlock</groupId>
+    <artifactId>shedlock-provider-redis-spring</artifactId>
+    <version>4.37.0</version>
+</dependency>
+```
+
+and configure
+
+```java
+import net.javacrumbs.shedlock.provider.redis.spring.ReactiveRedisLockProvider;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+
+...
+
+@Bean
+public LockProvider lockProvider(ReactiveRedisConnectionFactory connectionFactory) {
+    return new ReactiveRedisLockProvider(connectionFactory, ENV);
 }
 ```
 

--- a/providers/redis/shedlock-provider-redis-spring/pom.xml
+++ b/providers/redis/shedlock-provider-redis-spring/pom.xml
@@ -28,6 +28,7 @@
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
             <version>3.4.19</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/providers/redis/shedlock-provider-redis-spring/pom.xml
+++ b/providers/redis/shedlock-provider-redis-spring/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.4.19</version>
+        </dependency>
+
+        <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-test-support</artifactId>
             <version>${project.version}</version>

--- a/providers/redis/shedlock-provider-redis-spring/src/main/java/net/javacrumbs/shedlock/provider/redis/spring/ReactiveRedisLockProvider.java
+++ b/providers/redis/shedlock-provider-redis-spring/src/main/java/net/javacrumbs/shedlock/provider/redis/spring/ReactiveRedisLockProvider.java
@@ -1,0 +1,148 @@
+package net.javacrumbs.shedlock.provider.redis.spring;
+
+import net.javacrumbs.shedlock.core.AbstractSimpleLock;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.support.LockException;
+import net.javacrumbs.shedlock.support.annotation.NonNull;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static net.javacrumbs.shedlock.support.Utils.getHostname;
+import static net.javacrumbs.shedlock.support.Utils.toIsoString;
+
+/**
+ * Uses Redis's `SET resource-name anystring NX PX max-lock-ms-time` as locking mechanism.
+ * See https://redis.io/commands/set
+ */
+public class ReactiveRedisLockProvider implements LockProvider {
+    private static final String KEY_PREFIX_DEFAULT = "job-lock";
+    private static final String ENV_DEFAULT = "default";
+
+    private final ReactiveStringRedisTemplate redisTemplate;
+    private final String environment;
+    private final String keyPrefix;
+
+    public ReactiveRedisLockProvider(@NonNull ReactiveRedisConnectionFactory redisConn) {
+        this(redisConn, ENV_DEFAULT);
+    }
+
+    /**
+     * Creates ReactiveRedisLockProvider
+     *
+     * @param redisConn   ReactiveRedisConnectionFactory
+     * @param environment environment is part of the key and thus makes sure there is not key conflict between
+     *                    multiple ShedLock instances running on the same Redis
+     */
+    public ReactiveRedisLockProvider(@NonNull ReactiveRedisConnectionFactory redisConn, @NonNull String environment) {
+        this(redisConn, environment, KEY_PREFIX_DEFAULT);
+    }
+
+    /**
+     * Creates ReactiveRedisLockProvider
+     *
+     * @param redisConn   ReactiveRedisConnectionFactory
+     * @param environment environment is part of the key and thus makes sure there is not key conflict between
+     *                    multiple ShedLock instances running on the same Redis
+     * @param keyPrefix   prefix of the key in Redis.
+     */
+    public ReactiveRedisLockProvider(@NonNull ReactiveRedisConnectionFactory redisConn, @NonNull String environment, @NonNull String keyPrefix) {
+        this(new ReactiveStringRedisTemplate(redisConn), environment, keyPrefix);
+    }
+
+    /**
+     * Create ReactiveRedisLockProvider
+     *
+     * @param redisTemplate ReactiveStringRedisTemplate
+     * @param environment   environment is part of the key and thus makes sure there is not key conflict between
+     *                      multiple ShedLock instances running on the same Redis
+     * @param keyPrefix     prefix of the key in Redis.
+     */
+    public ReactiveRedisLockProvider(@NonNull ReactiveStringRedisTemplate redisTemplate, @NonNull String environment, @NonNull String keyPrefix) {
+        this.redisTemplate = redisTemplate;
+        this.environment = environment;
+        this.keyPrefix = keyPrefix;
+    }
+
+    @Override
+    public Optional<SimpleLock> lock(LockConfiguration lockConfiguration) {
+        Instant now = ClockProvider.now();
+        String key = ReactiveRedisLock.createKey(keyPrefix, environment, lockConfiguration.getName());
+        String value = ReactiveRedisLock.createValue(now);
+        Duration expirationTime = Duration.between(now, lockConfiguration.getLockAtMostUntil());
+        Boolean lockResult = redisTemplate.opsForValue().setIfAbsent(key, value, expirationTime).block();
+        if (Boolean.TRUE.equals(lockResult)) {
+            return Optional.of(new ReactiveRedisLock(key, redisTemplate, lockConfiguration));
+        }
+        return Optional.empty();
+    }
+
+    private static final class ReactiveRedisLock extends AbstractSimpleLock {
+        private final String key;
+        private final ReactiveStringRedisTemplate redisTemplate;
+
+        private static String createKey(String keyPrefix, String environment, String lockName) {
+            return String.format("%s:%s:%s", keyPrefix, environment, lockName);
+        }
+
+        private static String createValue(Instant now) {
+            return String.format("ADDED:%s@%s", toIsoString(now), getHostname());
+        }
+
+        private ReactiveRedisLock(String key, ReactiveStringRedisTemplate redisTemplate, LockConfiguration lockConfiguration) {
+            super(lockConfiguration);
+            this.key = key;
+            this.redisTemplate = redisTemplate;
+        }
+
+        @Override
+        protected void doUnlock() {
+            Instant now = ClockProvider.now();
+            Duration expirationTime = Duration.between(now, lockConfiguration.getLockAtLeastUntil());
+            if (expirationTime.isNegative() || expirationTime.isZero()) {
+                try {
+                    redisTemplate.delete(key).block();
+                } catch (Exception e) {
+                    throw new LockException("Can not remove node", e);
+                }
+            } else {
+                String value = createValue(now);
+                redisTemplate.opsForValue().setIfPresent(key, value, expirationTime).block();
+            }
+        }
+    }
+
+    public static class Builder {
+        private final ReactiveStringRedisTemplate redisTemplate;
+        private String environment = ENV_DEFAULT;
+        private String keyPrefix = KEY_PREFIX_DEFAULT;
+
+        public Builder(@NonNull ReactiveRedisConnectionFactory redisConnectionFactory) {
+            this.redisTemplate = new ReactiveStringRedisTemplate(redisConnectionFactory);
+        }
+
+        public Builder(@NonNull ReactiveStringRedisTemplate redisTemplate) {
+            this.redisTemplate = redisTemplate;
+        }
+
+        public ReactiveRedisLockProvider.Builder environment(@NonNull String environment) {
+            this.environment = environment;
+            return this;
+        }
+
+        public ReactiveRedisLockProvider.Builder keyPrefix(@NonNull String keyPrefix) {
+            this.keyPrefix = keyPrefix;
+            return this;
+        }
+
+        public ReactiveRedisLockProvider build() {
+            return new ReactiveRedisLockProvider(redisTemplate, environment, keyPrefix);
+        }
+    }
+}

--- a/providers/redis/shedlock-provider-redis-spring/src/test/java/net/javacrumbs/shedlock/provider/redis/spring/AbstractReactiveRedisLockProviderIntegrationTest.java
+++ b/providers/redis/shedlock-provider-redis-spring/src/test/java/net/javacrumbs/shedlock/provider/redis/spring/AbstractReactiveRedisLockProviderIntegrationTest.java
@@ -1,0 +1,44 @@
+package net.javacrumbs.shedlock.provider.redis.spring;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.test.support.AbstractLockProviderIntegrationTest;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractReactiveRedisLockProviderIntegrationTest extends AbstractLockProviderIntegrationTest {
+    private final ReactiveRedisLockProvider lockProvider;
+    private final ReactiveStringRedisTemplate redisTemplate;
+
+    private final static String ENV = "test";
+    private final static String KEY_PREFIX = "test-prefix";
+
+    public AbstractReactiveRedisLockProviderIntegrationTest(ReactiveRedisConnectionFactory connectionFactory) {
+        lockProvider = new ReactiveRedisLockProvider.Builder(connectionFactory)
+            .environment(ENV)
+            .keyPrefix(KEY_PREFIX)
+            .build();
+
+        redisTemplate = new ReactiveStringRedisTemplate(connectionFactory);
+    }
+
+    @Override
+    protected LockProvider getLockProvider() {
+        return lockProvider;
+    }
+
+    @Override
+    protected void assertUnlocked(String lockName) {
+        assertThat(redisTemplate.hasKey(createKey(lockName)).block()).isFalse();
+    }
+
+    @Override
+    protected void assertLocked(String lockName) {
+        assertThat(redisTemplate.getExpire(createKey(lockName)).block()).isPositive();
+    }
+
+    private String createKey(String lockName) {
+        return KEY_PREFIX + ":" + ENV + ":" + lockName;
+    }
+}

--- a/providers/redis/shedlock-provider-redis-spring/src/test/java/net/javacrumbs/shedlock/provider/redis/spring/SpringRedisLockProviderIntegrationTest.java
+++ b/providers/redis/shedlock-provider-redis-spring/src/test/java/net/javacrumbs/shedlock/provider/redis/spring/SpringRedisLockProviderIntegrationTest.java
@@ -68,7 +68,14 @@ public class SpringRedisLockProviderIntegrationTest {
         }
     }
 
-    private static RedisConnectionFactory createLettuceConnectionFactory() {
+    @Nested
+    class ReactiveLetucce extends AbstractReactiveRedisLockProviderIntegrationTest {
+        public ReactiveLetucce() {
+            super(createLettuceConnectionFactory());
+        }
+    }
+
+    private static LettuceConnectionFactory createLettuceConnectionFactory() {
         LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(HOST, PORT);
         lettuceConnectionFactory.afterPropertiesSet();
         return lettuceConnectionFactory;


### PR DESCRIPTION
Hi team, our team uses spring boot webflux and spring-data-redis to support a highly scalable platform and didn't find any LockProvider support for ReactiveRedisConnectionFactory. It is part of the spring-data-redis. Similar to R2DBC, the only new maven dependency is `reactor-core`. May I merge this PR to improve the overall support for spring reactor project?