### PR TITLE
feature/#1006 Support couchbase collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,42 @@ public CouchbaseLockProvider lockProvider(Bucket bucket) {
     return new CouchbaseLockProvider(bucket);
 }
 ```
+<hr>
+Or, to use Couchbase collections, you can create new class by implementing CouchbaseLockConfiguration
+and override methods.
+
+```java
+import net.javacrumbs.shedlock.provider.couchbase.javaclient.CouchbaseLockProvider;
+
+class ShedlockCouchbaseWithCollection implements CouchbaseLockConfiguration {
+
+    private final Bucket bucket;
+
+    private final Collection lockCollection;
+
+    public ShedlockCouchbaseWithCollection(Bucket bucket, Collection lockCollection) {
+        this.bucket = bucket;
+        this.lockCollection = collection;
+    }
+
+    @Override
+    public Bucket getBucket() {
+        return this.bucket;
+    }
+
+    @Override
+    public Collection getCollection() {
+        return this.lockCollection;
+    }
+}
+
+class ShedlockConfiguration {
+    @Bean
+    public CouchbaseLockProvider lockProvider(ShedlockCouchbaseWithCollection shedlockCouchbaseWithCollection) {
+        return new CouchbaseLockProvider(shedlockCouchbaseWithCollection);
+    }
+}
+```
 
 For Couchbase 3 use `shedlock-provider-couchbase-javaclient3` module and `net.javacrumbs.shedlock.provider.couchbase3` package.
 

--- a/providers/couchbase/shedlock-provider-couchbase-javaclient3/pom.xml
+++ b/providers/couchbase/shedlock-provider-couchbase-javaclient3/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.5</version>
+            <version>3.2.0</version>
         </dependency>
 
         <dependency>

--- a/providers/couchbase/shedlock-provider-couchbase-javaclient3/src/main/java/net/javacrumbs/shedlock/provider/couchbase/javaclient3/CouchbaseLockConfiguration.java
+++ b/providers/couchbase/shedlock-provider-couchbase-javaclient3/src/main/java/net/javacrumbs/shedlock/provider/couchbase/javaclient3/CouchbaseLockConfiguration.java
@@ -1,0 +1,24 @@
+package net.javacrumbs.shedlock.provider.couchbase.javaclient3;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Collection;
+
+public interface CouchbaseLockConfiguration {
+
+    Bucket getBucket();
+
+    Collection getCollection();
+
+    default Collection collection() {
+        if (this.getCollection() == null) {
+            if (this.getBucket() == null) {
+                throw new IllegalArgumentException("Bucket can not be null.");
+            }
+
+            return this.getBucket().defaultCollection();
+        }
+
+        return this.getCollection();
+    }
+}
+

--- a/providers/couchbase/shedlock-provider-couchbase-javaclient3/src/main/java/net/javacrumbs/shedlock/provider/couchbase/javaclient3/DefaultCouchbaseLockConfiguration.java
+++ b/providers/couchbase/shedlock-provider-couchbase-javaclient3/src/main/java/net/javacrumbs/shedlock/provider/couchbase/javaclient3/DefaultCouchbaseLockConfiguration.java
@@ -1,0 +1,35 @@
+package net.javacrumbs.shedlock.provider.couchbase.javaclient3;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Collection;
+
+public class DefaultCouchbaseLockConfiguration implements CouchbaseLockConfiguration {
+
+    private final Bucket bucket;
+
+    private final Collection collection;
+
+    public DefaultCouchbaseLockConfiguration(Bucket bucket) {
+        this(bucket, null);
+    }
+
+    public DefaultCouchbaseLockConfiguration(Bucket bucket, Collection collection) {
+        this.bucket = bucket;
+        this.collection = collection;
+    }
+
+    @Override
+    public Bucket getBucket() {
+        return this.bucket;
+    }
+
+    @Override
+    public Collection getCollection() {
+        if (this.collection == null) {
+            return this.bucket.defaultCollection();
+        }
+
+        return this.collection;
+    }
+}
+

--- a/providers/couchbase/shedlock-provider-couchbase-javaclient3/src/test/java/net/javacrumbs/shedlock/provider/couchbase/javaclient3/CouchbaseCollectionLockProviderIntegrationTest.java
+++ b/providers/couchbase/shedlock-provider-couchbase-javaclient3/src/test/java/net/javacrumbs/shedlock/provider/couchbase/javaclient3/CouchbaseCollectionLockProviderIntegrationTest.java
@@ -1,26 +1,13 @@
-/**
- * Copyright 2009 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package net.javacrumbs.shedlock.provider.couchbase.javaclient3;
 
 import com.couchbase.client.core.env.SeedNode;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
+import com.couchbase.client.java.Collection;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.kv.GetResult;
+import com.couchbase.client.java.manager.collection.CollectionSpec;
 import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
 import net.javacrumbs.shedlock.test.support.AbstractStorageBasedLockProviderIntegrationTest;
 import org.junit.jupiter.api.AfterAll;
@@ -44,13 +31,17 @@ import static net.javacrumbs.shedlock.provider.couchbase.javaclient3.CouchbaseLo
 import static net.javacrumbs.shedlock.provider.couchbase.javaclient3.CouchbaseLockProvider.LOCK_UNTIL;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CouchbaseLockProviderIntegrationTest extends AbstractStorageBasedLockProviderIntegrationTest {
+public class CouchbaseCollectionLockProviderIntegrationTest extends AbstractStorageBasedLockProviderIntegrationTest {
 
-    private static final String BUCKET_NAME = "test";
+    private static final String BUCKET_NAME = "testBucket";
+
+    private static final String COLLECTION_NAME = "testCollection";
 
     private CouchbaseLockProvider lockProvider;
+    private CouchbaseLockConfiguration couchbaseLockConfiguration;
     private static Cluster cluster;
     private static Bucket bucket;
+    private static Collection collection;
     private static CouchbaseContainer container;
 
     @BeforeAll
@@ -67,6 +58,8 @@ public class CouchbaseLockProviderIntegrationTest extends AbstractStorageBasedLo
         cluster = Cluster.connect(seedNodes, options);
         bucket = cluster.bucket(BUCKET_NAME);
         bucket.waitUntilReady(Duration.ofSeconds(30));
+        bucket.collections().createCollection(CollectionSpec.create(COLLECTION_NAME, "_default"));
+        collection = bucket.collection(COLLECTION_NAME);
     }
 
     @AfterAll
@@ -77,13 +70,14 @@ public class CouchbaseLockProviderIntegrationTest extends AbstractStorageBasedLo
 
     @BeforeEach
     public void createLockProvider()  {
-        lockProvider = new CouchbaseLockProvider(bucket);
+        couchbaseLockConfiguration = new DefaultCouchbaseLockConfiguration(bucket, collection);
+        lockProvider = new CouchbaseLockProvider(couchbaseLockConfiguration);
     }
 
     @AfterEach
     public void clear() {
         try {
-            bucket.defaultCollection().remove(LOCK_NAME1);
+            couchbaseLockConfiguration.collection().remove(LOCK_NAME1);
         } catch (Exception e) {
             // ignore
         }
@@ -96,7 +90,7 @@ public class CouchbaseLockProviderIntegrationTest extends AbstractStorageBasedLo
 
     @Override
     public void assertUnlocked(String lockName) {
-        GetResult result = bucket.defaultCollection().get(lockName);
+        GetResult result = couchbaseLockConfiguration.collection().get(lockName);
         JsonObject lockDocument = result.contentAsObject();
 
         assertThat(parse((String) lockDocument.get(LOCK_UNTIL))).isBeforeOrEqualTo(now());
@@ -106,7 +100,7 @@ public class CouchbaseLockProviderIntegrationTest extends AbstractStorageBasedLo
 
     @Override
     public void assertLocked(String lockName) {
-        GetResult result = bucket.defaultCollection().get(lockName);
+        GetResult result = couchbaseLockConfiguration.collection().get(lockName);
         JsonObject lockDocument = result.contentAsObject();
 
         assertThat(parse((String) lockDocument.get(LOCK_UNTIL))).isAfter(now());
@@ -114,3 +108,4 @@ public class CouchbaseLockProviderIntegrationTest extends AbstractStorageBasedLo
         assertThat(lockDocument.get(LOCKED_BY)).asString().isNotEmpty();
     }
 }
+


### PR DESCRIPTION
Current version is only supporting default-collection. With this development,
CouchbaseLockProvider is supporting different Collection with-in a Bucket and
this is provided by a class which is implemented by using
CouchbaseLockConfiguration interface.

Couchbase needed a new version because of Collections support. And which is why
it's updated from 3.0.5 to 3.2.0 and has not been observed any backward
compatibility issue.

README.md updated for these changes.