### PR TITLE
Better insert statement for MySQL

### DIFF
--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/MySqlServerTimeStatementsSource.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/MySqlServerTimeStatementsSource.java
@@ -35,9 +35,9 @@ class MySqlServerTimeStatementsSource extends SqlStatementsSource {
 		" ON DUPLICATE KEY UPDATE " + updateClause();
     }
 	
-	@NonNull
+    @NonNull
     private String updateClause() {
-        return lockUntil() + " = " + lockAtMostFor + ", " + lockedAt() + " = " + now + ", " + lockedBy() + " = :lockedBy;
+        return lockUntil() + " = " + lockAtMostFor + ", " + lockedAt() + " = " + now + ", " + lockedBy() + " = :lockedBy ";
     }
 
     @Override

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/MySqlServerTimeStatementsSource.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/MySqlServerTimeStatementsSource.java
@@ -36,9 +36,12 @@ class MySqlServerTimeStatementsSource extends SqlStatementsSource {
     }
 	
     @NonNull
-    private String updateClause() {
-        return lockUntil() + " = " + lockAtMostFor + ", " + lockedAt() + " = " + now + ", " + lockedBy() + " = :lockedBy ";
-    }
+	private String updateClause() {
+		return lockUntil() + " = IF(" + lockUntil() + "<= " + now + ", VALUES(" + lockUntil() + ")," + lockUntil() + ")"
+				+ ", " + lockedAt() + " = IF(" + lockUntil() + "<= " + now + ", VALUES(" + lockedAt() + "),"
+				+ lockedAt() + ")" + ", " + lockedBy() + " = IF(" + lockUntil() + "<= " + now + ", VALUES(" + lockedBy()
+				+ ")," + lockedBy() + ")";
+	}
 
     @Override
     public String getUpdateStatement() {

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/MySqlServerTimeStatementsSource.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/MySqlServerTimeStatementsSource.java
@@ -31,7 +31,13 @@ class MySqlServerTimeStatementsSource extends SqlStatementsSource {
 
     @Override
     String getInsertStatement() {
-        return "INSERT INTO " + tableName() + "(" + name() + ", " + lockUntil() + ", " + lockedAt() + ", " + lockedBy() + ") VALUES(:name, " + lockAtMostFor + ", " + now + ", :lockedBy)";
+        return "INSERT INTO " + tableName() + "(" + name() + ", " + lockUntil() + ", " + lockedAt() + ", " + lockedBy() + ") VALUES(:name, " + lockAtMostFor + ", " + now + ", :lockedBy)" + 
+		" ON DUPLICATE KEY UPDATE " + updateClause();
+    }
+	
+	@NonNull
+    private String updateClause() {
+        return lockUntil() + " = " + lockAtMostFor + ", " + lockedAt() + " = " + now + ", " + lockedBy() + " = :lockedBy;
     }
 
     @Override


### PR DESCRIPTION
@lukas-krecan Syntax error has been corrected, can you please check it now

Mysql update on conflict syntax works as below

INSERT INTO shedlock(name,lock_until,locked_at,locked_by) 
VALUES('shedlock', '2022-09-05 11:58:52.059', '2022-09-05 12:58:52.059','admin') 
ON DUPLICATE KEY UPDATE lock_until = '2022-10-31 11:58:52.059', locked_at= '2022-10-31 12:58:52.059', locked_by='Iadmin';

MySql reference link - 

https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html