### PR TITLE
Upgrade to R2DBC 1.0.0.Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <assertj.ver>3.23.1</assertj.ver>
         <mockito.ver>4.9.0</mockito.ver>
         <slf4j.ver>2.0.5</slf4j.ver>
+        <r2dbc.version>1.0.0.RELEASE</r2dbc.version>
     </properties>
 
     <build>

--- a/providers/jdbc/shedlock-test-support-jdbc/src/main/java/net/javacrumbs/shedlock/test/support/jdbc/MySqlConfig.java
+++ b/providers/jdbc/shedlock-test-support-jdbc/src/main/java/net/javacrumbs/shedlock/test/support/jdbc/MySqlConfig.java
@@ -23,6 +23,7 @@ public class MySqlConfig extends AbstractContainerBasedDbConfig<MySqlConfig.MyMy
             .withDatabaseName(TEST_SCHEMA_NAME)
             .withUsername("SA")
             .withPassword("pass")
+            .withCommand("--default-authentication-plugin=mysql_native_password")
         );
     }
 

--- a/providers/r2dbc/shedlock-provider-r2dbc/pom.xml
+++ b/providers/r2dbc/shedlock-provider-r2dbc/pom.xml
@@ -22,6 +22,7 @@
         <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-spi</artifactId>
+            <version>${r2dbc.version}</version>
         </dependency>
 
         <dependency>
@@ -41,25 +42,29 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>r2dbc-postgresql</artifactId>
+            <!-- Maintained in as pgjdbc project with own release cycle -->
+            <version>1.0.0.RELEASE</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-mssql</artifactId>
+            <version>${r2dbc.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>dev.miku</groupId>
-            <artifactId>r2dbc-mysql</artifactId>
-            <version>0.8.2.RELEASE</version>
+            <groupId>com.github.jasync-sql</groupId>
+            <artifactId>jasync-r2dbc-mysql</artifactId>
+            <version>2.1.7</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.oracle.database.r2dbc</groupId>
             <artifactId>oracle-r2dbc</artifactId>
+            <version>1.1.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -73,18 +78,21 @@
         <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-h2</artifactId>
+            <version>${r2dbc.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mariadb</groupId>
             <artifactId>r2dbc-mariadb</artifactId>
+            <version>1.1.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-pool</artifactId>
+            <version>${r2dbc.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -95,18 +103,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.r2dbc</groupId>
-                <artifactId>r2dbc-bom</artifactId>
-                <version>Borca-SR1</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/providers/r2dbc/shedlock-provider-r2dbc/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/R2dbcAdapter.java
+++ b/providers/r2dbc/shedlock-provider-r2dbc/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/R2dbcAdapter.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 abstract class R2dbcAdapter {
     private static final String MSSQL_NAME = "Microsoft SQL Server";
     private static final String MYSQL_NAME = "MySQL";
+    private static final String JASYNC_MYSQL_NAME = "Jasync-MySQL";
     private static final String MARIA_NAME = "MariaDB";
     private static final String ORACLE_NAME = "Oracle Database";
 
@@ -23,6 +24,7 @@ abstract class R2dbcAdapter {
                     R2dbcAdapter::bindByName
                 );
             case MYSQL_NAME:
+            case JASYNC_MYSQL_NAME:
             case MARIA_NAME:
                 return new DefaultR2dbcAdapter(
                     (index, name) -> "?",

--- a/providers/r2dbc/shedlock-provider-r2dbc/src/test/java/net/javacrumbs/shedlock/provider/r2dbc/MariaR2dbcLockProviderIntegrationTest.java
+++ b/providers/r2dbc/shedlock-provider-r2dbc/src/test/java/net/javacrumbs/shedlock/provider/r2dbc/MariaR2dbcLockProviderIntegrationTest.java
@@ -17,7 +17,9 @@ package net.javacrumbs.shedlock.provider.r2dbc;
 
 import net.javacrumbs.shedlock.test.support.jdbc.DbConfig;
 import net.javacrumbs.shedlock.test.support.jdbc.MariaDbConfig;
+import org.junit.jupiter.api.Disabled;
 
+@Disabled("No R2DBC 1.0.0 compatible driver")
 public class MariaR2dbcLockProviderIntegrationTest extends AbstractR2dbcTest {
     private static final DbConfig dbConfig = new MariaDbConfig();
 


### PR DESCRIPTION
Notes:

- MySQL native driver sims are not active anymore so Jasync driver support introduced
- MariaDB has not migrated to R2DBC 1.0.0 yet ( https://jira.mariadb.org/browse/R2DBC-60 ), so test disabled

Update: Oracle test enabled - thanks to Michael McMahon