### PR TITLE
#1284 Added SpEL support to @SchedulerLock name attribute

### DIFF
--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/ExtendedLockConfigurationExtractor.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/ExtendedLockConfigurationExtractor.java
@@ -25,5 +25,5 @@ public interface ExtendedLockConfigurationExtractor extends LockConfigurationExt
     /**
      * Extracts lock configuration for given method
      */
-    Optional<LockConfiguration> getLockConfiguration(Object object, Method method);
+    Optional<LockConfiguration> getLockConfiguration(Object object, Method method, Object[] parameterValues);
 }

--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyScheduledLockAdvisor.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyScheduledLockAdvisor.java
@@ -79,7 +79,7 @@ class MethodProxyScheduledLockAdvisor extends AbstractPointcutAdvisor {
                 throw new LockingNotSupportedException("Can not lock method returning primitive value");
             }
 
-            LockConfiguration lockConfiguration = lockConfigurationExtractor.getLockConfiguration(invocation.getThis(), invocation.getMethod()).get();
+            LockConfiguration lockConfiguration = lockConfigurationExtractor.getLockConfiguration(invocation.getThis(), invocation.getMethod(), invocation.getArguments()).get();
             TaskResult<Object> result = lockingTaskExecutor.executeWithLock(invocation::proceed, lockConfiguration);
 
             if (Optional.class.equals(returnType)) {

--- a/spring/shedlock-spring/src/test/java/net/javacrumbs/shedlock/spring/aop/AbstractSpringLockConfigurationExtractorTest.java
+++ b/spring/shedlock-spring/src/test/java/net/javacrumbs/shedlock/spring/aop/AbstractSpringLockConfigurationExtractorTest.java
@@ -15,6 +15,8 @@
  */
 package net.javacrumbs.shedlock.spring.aop;
 
+import java.lang.reflect.Method;
+
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.spring.aop.SpringLockConfigurationExtractor.AnnotationData;
 import net.javacrumbs.shedlock.spring.proxytest.BeanInterface;
@@ -151,6 +153,22 @@ public abstract class AbstractSpringLockConfigurationExtractorTest {
         ScheduledMethodRunnable runnable = new ScheduledMethodRunnable(this, "annotatedMethodWithNameVariable");
         LockConfiguration lockConfiguration = extractor.getLockConfiguration(runnable).get();
         assertThat(lockConfiguration.getName()).isEqualTo("lockNameX");
+    }
+
+    @Test
+    public void shouldGetNameFromSpringExpression() throws NoSuchMethodException {
+        mockResolvedValue("lockName-value-1-3-5", "lockName-value-1-3-5");
+        Method method = this.getClass().getMethod("annotatedMethodWithNameSpringExpression", String.class, Integer.class);
+        LockConfiguration lockConfiguration = extractor.getLockConfiguration(this, method, new Object[] {"value", 1}).get();
+        assertThat(lockConfiguration.getName()).isEqualTo("lockName-value-1-3-5");
+    }
+
+    @Test
+    public void shouldGetNameFromSpringExpressionAndSpringVariable() throws NoSuchMethodException {
+        mockResolvedValue("${name}-value", "lockName-value");
+        Method method = this.getClass().getMethod("annotatedMethodWithNameSpringExpressionAndVariable", String.class);
+        LockConfiguration lockConfiguration = extractor.getLockConfiguration(this, method, new Object[] {"value"}).get();
+        assertThat(lockConfiguration.getName()).isEqualTo("lockName-value");
     }
 
     private void mockResolvedValue(String expression, String resolved) {

--- a/spring/shedlock-spring/src/test/java/net/javacrumbs/shedlock/spring/aop/SpringLockConfigurationExtractorTest.java
+++ b/spring/shedlock-spring/src/test/java/net/javacrumbs/shedlock/spring/aop/SpringLockConfigurationExtractorTest.java
@@ -48,6 +48,16 @@ public class SpringLockConfigurationExtractorTest extends AbstractSpringLockConf
 
     }
 
+    @SchedulerLock(name = "lockName-#{#arg0 + '-' + #arg1 + '-' + (1 + 2) + '-' + 'abcde'.length()}")
+    public void annotatedMethodWithNameSpringExpression(String arg0, Integer arg1) {
+
+    }
+
+    @SchedulerLock(name = "${name}-#{#arg0}")
+    public void annotatedMethodWithNameSpringExpressionAndVariable(String arg0) {
+
+    }
+
     @SchedulerLock(name = "lockName")
     public void annotatedMethodWithoutLockAtMostFor() {
 


### PR DESCRIPTION
This PR adds SpEL support to @SchedulerLock "name" attribute (#1284)

I think it does not add much complexity to ShedLock.

What do you think @lukas-krecan?