### PR TITLE
Issue #1362: Give the possibility to make table- and column names uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,16 @@ new JdbcTemplateLockProvider(builder()
     .withColumnNames(new ColumnNames("n", "lck_untl", "lckd_at", "lckd_by"))
     .withJdbcTemplate(new JdbcTemplate(getDatasource()))
     .withLockedByValue("my-value")
+    .withDbUpperCase(true)
     .build())
 ```
 
 If you need to specify a schema, you can set it in the table name using the usual dot notation
 `new JdbcTemplateLockProvider(datasource, "my_schema.shedlock")`
+
+To use a database with case-sensitive table and column names, the `.withDbUpperCase(true)` flag can be used.
+Default is `false` (lowercase).
+
 
 #### Warning
 **Do not manually delete lock row from the DB table.** ShedLock has an in-memory cache of existing lock rows

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
@@ -152,7 +152,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
         }
 
         public static Configuration.Builder builder() {
-            return new Configuration.Builder();
+            return new Builder();
         }
 
 
@@ -163,6 +163,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
             private TimeZone timeZone;
             private String lockedByValue = Utils.getHostname();
             private ColumnNames columnNames = new ColumnNames("name", "lock_until", "locked_at", "locked_by");
+            private boolean dbUpperCase = false;
             private boolean useDbTime = false;
             private Integer isolationLevel;
 
@@ -191,6 +192,12 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
                 return this;
             }
 
+            public Builder withDbUpperCase (final boolean dbUppercase) {
+                this.dbUpperCase = dbUppercase;
+                return this;
+            }
+
+
             /**
              * Value stored in 'locked_by' column. Please use only for debugging purposes.
              */
@@ -214,7 +221,33 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
             }
 
             public JdbcTemplateLockProvider.Configuration build() {
-                return new JdbcTemplateLockProvider.Configuration(jdbcTemplate, transactionManager, tableName, timeZone, columnNames, lockedByValue, useDbTime, isolationLevel);
+                // react on uppercase
+                return new JdbcTemplateLockProvider.Configuration(
+                    jdbcTemplate,
+                    transactionManager,
+                    tableNameToUpperIfReq(),
+                    timeZone,
+                    columnNamesToUpperIfReq(),
+                    lockedByValue,
+                    useDbTime,
+                    isolationLevel
+                );
+            }
+
+            private String tableNameToUpperIfReq() {
+                return dbUpperCase ? tableName.toUpperCase() : tableName;
+            }
+
+            private ColumnNames columnNamesToUpperIfReq() {
+                if (dbUpperCase) {
+                    return new ColumnNames(
+                        columnNames.name.toUpperCase(),
+                        columnNames.lockUntil.toUpperCase(),
+                        columnNames.lockedAt.toUpperCase(),
+                        columnNames.lockedBy.toUpperCase()
+                    );
+                }
+                return columnNames;
             }
         }
 

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
@@ -152,7 +152,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
         }
 
         public static Configuration.Builder builder() {
-            return new Builder();
+            return new Configuration.Builder();
         }
 
 

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/test/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProviderTest.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/test/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProviderTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2009 the original author or authors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.TimeZone;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
@@ -34,5 +35,36 @@ class JdbcTemplateLockProviderTest {
                 .usingDbTime()
                 .build()
         ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldTableAndColumNamesUpperCase() {
+        final var config = JdbcTemplateLockProvider
+            .Configuration
+            .builder()
+            .withJdbcTemplate(mock(JdbcTemplate.class))
+            .withDbUpperCase(true)
+            .build();
+
+        assertThat(config.getTableName()).isUpperCase();
+        assertThat(config.getColumnNames().getName()).isUpperCase();
+        assertThat(config.getColumnNames().getLockedBy()).isUpperCase();
+        assertThat(config.getColumnNames().getLockedAt()).isUpperCase();
+        assertThat(config.getColumnNames().getLockUntil()).isUpperCase();
+    }
+
+    @Test
+    void shouldTableAndColumNamesLowerCaseByDefault() {
+        final var config = JdbcTemplateLockProvider
+            .Configuration
+            .builder()
+            .withJdbcTemplate(mock(JdbcTemplate.class))
+            .build();
+
+        assertThat(config.getTableName()).isLowerCase();
+        assertThat(config.getColumnNames().getName()).isLowerCase();
+        assertThat(config.getColumnNames().getLockedBy()).isLowerCase();
+        assertThat(config.getColumnNames().getLockedAt()).isLowerCase();
+        assertThat(config.getColumnNames().getLockUntil()).isLowerCase();
     }
 }


### PR DESCRIPTION
Solves the issue #1362 with the possibility to define in the builder if table- and column names should be uppercase.