### PR TITLE
Allow users to configure DatabaseProductName if needed

### DIFF
--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/DatabaseProduct.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/DatabaseProduct.java
@@ -1,0 +1,36 @@
+package net.javacrumbs.shedlock.provider.jdbctemplate;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+public enum DatabaseProduct {
+
+    PostgresSQL("PostgreSQL"::equals),
+    SQLServer("Microsoft SQL Server"::equals),
+    Oracle("Oracle"::equals),
+    MySQL("MySQL"::equals),
+    MariaDB("MariaDB"::equals),
+    HQL("HSQL Database Engine"::equals),
+    H2("H2"::equals),
+    DB2(s -> s.startsWith("DB2")),
+    Unknown(s -> false);
+
+    private final Predicate<String> productMatcher;
+
+    DatabaseProduct(Predicate<String> productMatcher) {
+        this.productMatcher = productMatcher;
+    }
+
+    /**
+     * Searches for the right DatabaseProduct based on the ProductName returned from JDBC Connection Metadata
+     *
+     * @param productName Obtained from the JDBC connection. See java.sql.connection.getMetaData().getProductName().
+     * @return The matching ProductName enum
+     */
+    public static DatabaseProduct matchProductName(final String productName) {
+        return Arrays.stream(DatabaseProduct.values())
+            .filter(databaseProduct -> databaseProduct.productMatcher.test(productName))
+            .findFirst().orElse(null);
+    }
+}
+

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
@@ -200,8 +200,8 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
                 return this;
             }
 
-            public Builder withDbUpperCase(final boolean dbUppercase) {
-                this.dbUpperCase = dbUppercase;
+            public Builder withDbUpperCase(final boolean dbUpperCase) {
+                this.dbUpperCase = dbUpperCase;
                 return this;
             }
 

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2009 the original author or authors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -88,7 +88,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
 
     public static final class Configuration {
         private final JdbcTemplate jdbcTemplate;
-        private final String databaseProductName;
+        private final DatabaseProduct databaseProductName;
         private final PlatformTransactionManager transactionManager;
         private final String tableName;
         private final TimeZone timeZone;
@@ -99,7 +99,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
 
         Configuration(
             @NonNull JdbcTemplate jdbcTemplate,
-            @Nullable String databaseProductName,
+            @Nullable DatabaseProduct databaseProductName,
             @Nullable PlatformTransactionManager transactionManager,
             @NonNull String tableName,
             @Nullable TimeZone timeZone,
@@ -126,7 +126,9 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
             return jdbcTemplate;
         }
 
-        public String getDatabaseProductName() { return databaseProductName; }
+        public DatabaseProduct getDatabaseProductName() {
+            return databaseProductName;
+        }
 
         public PlatformTransactionManager getTransactionManager() {
             return transactionManager;
@@ -163,7 +165,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
 
         public static final class Builder {
             private JdbcTemplate jdbcTemplate;
-            private String databaseProductName;
+            private DatabaseProduct databaseProductName;
             private PlatformTransactionManager transactionManager;
             private String tableName = DEFAULT_TABLE_NAME;
             private TimeZone timeZone;
@@ -198,13 +200,18 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
                 return this;
             }
 
-            public Builder withDbUpperCase (final boolean dbUppercase) {
+            public Builder withDbUpperCase(final boolean dbUppercase) {
                 this.dbUpperCase = dbUppercase;
                 return this;
             }
 
-            public Builder withDatabaseProductName(final String databaseProductName){
-                this.databaseProductName = databaseProductName;
+            /**
+             * This is only needed if your database product can't be automatically detected.
+             * @param databaseProduct Database product
+             * @return ConfigurationBuilder
+             */
+            public Builder withDatabaseProductName(final DatabaseProduct databaseProduct) {
+                this.databaseProductName = databaseProduct;
                 return this;
             }
 

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/JdbcTemplateLockProvider.java
@@ -88,6 +88,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
 
     public static final class Configuration {
         private final JdbcTemplate jdbcTemplate;
+        private final String databaseProductName;
         private final PlatformTransactionManager transactionManager;
         private final String tableName;
         private final TimeZone timeZone;
@@ -98,6 +99,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
 
         Configuration(
             @NonNull JdbcTemplate jdbcTemplate,
+            @Nullable String databaseProductName,
             @Nullable PlatformTransactionManager transactionManager,
             @NonNull String tableName,
             @Nullable TimeZone timeZone,
@@ -107,6 +109,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
             @Nullable Integer isolationLevel) {
 
             this.jdbcTemplate = requireNonNull(jdbcTemplate, "jdbcTemplate can not be null");
+            this.databaseProductName = databaseProductName;
             this.transactionManager = transactionManager;
             this.tableName = requireNonNull(tableName, "tableName can not be null");
             this.timeZone = timeZone;
@@ -122,6 +125,8 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
         public JdbcTemplate getJdbcTemplate() {
             return jdbcTemplate;
         }
+
+        public String getDatabaseProductName() { return databaseProductName; }
 
         public PlatformTransactionManager getTransactionManager() {
             return transactionManager;
@@ -158,6 +163,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
 
         public static final class Builder {
             private JdbcTemplate jdbcTemplate;
+            private String databaseProductName;
             private PlatformTransactionManager transactionManager;
             private String tableName = DEFAULT_TABLE_NAME;
             private TimeZone timeZone;
@@ -197,6 +203,11 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
                 return this;
             }
 
+            public Builder withDatabaseProductName(final String databaseProductName){
+                this.databaseProductName = databaseProductName;
+                return this;
+            }
+
 
             /**
              * Value stored in 'locked_by' column. Please use only for debugging purposes.
@@ -223,6 +234,7 @@ public class JdbcTemplateLockProvider extends StorageBasedLockProvider {
             public JdbcTemplateLockProvider.Configuration build() {
                 return new JdbcTemplateLockProvider.Configuration(
                     jdbcTemplate,
+                    databaseProductName,
                     transactionManager,
                     dbUpperCase ? tableName.toUpperCase() : tableName,
                     timeZone,

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/SqlStatementsSource.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/SqlStatementsSource.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2009 the original author or authors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -92,6 +92,9 @@ class SqlStatementsSource {
     }
 
     private static String getDatabaseProductName(Configuration configuration) {
+        if (configuration.getDatabaseProductName() != null) {
+            return configuration.getDatabaseProductName();
+        }
         try {
             return configuration.getJdbcTemplate().execute((ConnectionCallback<String>) connection -> connection.getMetaData().getDatabaseProductName());
         } catch (Exception e) {

--- a/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/SqlStatementsSource.java
+++ b/providers/jdbc/shedlock-provider-jdbc-template/src/main/java/net/javacrumbs/shedlock/provider/jdbctemplate/SqlStatementsSource.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.TimeZone;
 
@@ -81,7 +82,7 @@ class SqlStatementsSource {
                     throw new UnsupportedOperationException("DB time is not supported for '" + databaseProduct + "'");
             }
         } else {
-            if (DatabaseProduct.PostgresSQL.equals(databaseProduct)) {
+            if (Objects.equals(databaseProduct, DatabaseProduct.PostgresSQL)) {
                 logger.debug("Using PostgresSqlServerTimeStatementsSource");
                 return new PostgresSqlStatementsSource(configuration);
             } else {


### PR DESCRIPTION

Related to #1477 

This PR allows users to set a `DatabaseProductName` in their configuration if they wish. This should be useful to people who have trouble with the jdbc call `connection.getMetaData().getDatabaseProductName()`.