### PR TITLE
Clarify locking logic in case of reentrant locks

### DIFF
--- a/shedlock-core/src/main/java/net/javacrumbs/shedlock/core/DefaultLockingTaskExecutor.java
+++ b/shedlock-core/src/main/java/net/javacrumbs/shedlock/core/DefaultLockingTaskExecutor.java
@@ -57,13 +57,14 @@ public class DefaultLockingTaskExecutor implements LockingTaskExecutor {
 
     @Override
     public <T> TaskResult<T> executeWithLock(TaskWithResult<T> task, LockConfiguration lockConfig) throws Throwable {
-        Optional<SimpleLock> lock = lockProvider.lock(lockConfig);
         String lockName = lockConfig.getName();
-
         if (alreadyLockedBy(lockName)) {
             logger.debug("Already locked '{}'", lockName);
             return TaskResult.result(task.call());
-        } else if (lock.isPresent()) {
+        }
+
+        Optional<SimpleLock> lock = lockProvider.lock(lockConfig);
+        if (lock.isPresent()) {
             try {
                 LockAssert.startLock(lockName);
                 LockExtender.startLock(lock.get());

--- a/shedlock-core/src/test/java/net/javacrumbs/shedlock/core/DefaultLockingTaskExecutorTest.java
+++ b/shedlock-core/src/test/java/net/javacrumbs/shedlock/core/DefaultLockingTaskExecutorTest.java
@@ -35,8 +35,7 @@ class DefaultLockingTaskExecutorTest {
     @Test
     void lockShouldBeReentrant() {
         when(lockProvider.lock(lockConfig))
-            .thenReturn(Optional.of(mock(SimpleLock.class)))
-            .thenReturn(Optional.empty());
+            .thenReturn(Optional.of(mock(SimpleLock.class)));
 
         AtomicBoolean called = new AtomicBoolean(false);
 


### PR DESCRIPTION
We do not need to try to lock if we already hold the lock. Moreover, the lock is not check nor released in the old solution.