### PR TITLE
Fix instruction typo for Micronaut 4 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ Import the project:
     <!-- Micronaut 3 -->
     <artifactId>shedlock-micronaut</artifactId>
     <!-- For Micronaut 4 use -->
-    <!-- <artifactId>shedlock-micronaut</artifactId> -->
+    <!-- <artifactId>shedlock-micronaut4</artifactId> -->
     <version>5.9.1</version>
 </dependency>
 ```


### PR DESCRIPTION
Minor typo correction in the README for Micronaut 4 integration. Using the `shedlock-micronaut` and not `shedlock-micronaut4` in Micronaut 4 results in issues configuring Shedlock.