### PR TITLE
Bump co.elastic.clients:elasticsearch-java from 8.14.3 to 8.15.0 and fix...

### DIFF
--- a/providers/elasticsearch/shedlock-provider-elasticsearch8/pom.xml
+++ b/providers/elasticsearch/shedlock-provider-elasticsearch8/pom.xml
@@ -12,7 +12,7 @@
     <version>5.14.1-SNAPSHOT</version>
 
     <properties>
-        <elasticsearch.version>8.14.3</elasticsearch.version>
+        <elasticsearch.version>8.15.0</elasticsearch.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <jackson.version>2.17.2</jackson.version>
     </properties>

--- a/providers/elasticsearch/shedlock-provider-elasticsearch8/src/main/java/net/javacrumbs/shedlock/provider/elasticsearch8/ElasticsearchLockProvider.java
+++ b/providers/elasticsearch/shedlock-provider-elasticsearch8/src/main/java/net/javacrumbs/shedlock/provider/elasticsearch8/ElasticsearchLockProvider.java
@@ -109,8 +109,7 @@ public class ElasticsearchLockProvider implements LockProvider {
             UpdateRequest<Lock, Lock> updateRequest = UpdateRequest.of(ur -> ur.index(index)
                     .id(lockConfiguration.getName())
                     .refresh(Refresh.True)
-                    .script(sc -> sc.inline(
-                            in -> in.lang("painless").source(UPDATE_SCRIPT).params(lockObject)))
+                    .script(sc -> sc.lang("painless").source(UPDATE_SCRIPT).params(lockObject))
                     .upsert(pojo));
 
             UpdateResponse<Lock> res = client.update(updateRequest, Lock.class);
@@ -163,9 +162,9 @@ public class ElasticsearchLockProvider implements LockProvider {
                 UpdateRequest<Lock, Lock> updateRequest = UpdateRequest.of(ur -> ur.index(index)
                         .id(lockConfiguration.getName())
                         .refresh(Refresh.True)
-                        .script(sc -> sc.inline(in -> in.lang("painless")
+                        .script(sc -> sc.lang("painless")
                                 .source("ctx._source.lockUntil = params.unlockTime")
-                                .params(lockObject))));
+                                .params(lockObject)));
                 client.update(updateRequest, Lock.class);
             } catch (IOException | ElasticsearchException e) {
                 throw new LockException("Unexpected exception occurred", e);


### PR DESCRIPTION
… changed API.

Bumping the elasticsearch-java dependency requires some fixes in the API usage.

Let me know what if I need to provide more/other information :).