### PR TITLE
Make Spring integration with InterceptMode.PROXY_METHOD work for Spring versions prior to 5.0.0

### DIFF
--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyScheduledLockAdvisor.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyScheduledLockAdvisor.java
@@ -44,11 +44,33 @@ class MethodProxyScheduledLockAdvisor extends AbstractPointcutAdvisor {
 
     @NonNull
     private static AnnotationMatchingPointcut methodPointcutFor(Class<? extends Annotation> methodAnnotationType) {
+        Integer springVersion = getSpringMajorVersion();
+        if (springVersion != null) {
+            if (springVersion < 2) {
+                throw new IllegalStateException("Spring < 2.x is not supported");
+            }
+            if (springVersion < 5) {
+                return new AnnotationMatchingPointcut(
+                    null,
+                    methodAnnotationType
+                );
+            }
+        }
         return new AnnotationMatchingPointcut(
             null,
             methodAnnotationType,
             true
         );
+    }
+
+    private static Integer getSpringMajorVersion() {
+        try {
+            String springVersion = SpringVersion.getVersion();
+            int dot = springVersion.indexOf('.');
+            return dot > 0 ? Integer.parseInt(springVersion.substring(0, dot)) : Integer.parseInt(springVersion);
+        } catch (NumberFormatException | NullPointerException e) {
+            return null;
+        }
     }
 
     /**

--- a/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyScheduledLockAdvisor.java
+++ b/spring/shedlock-spring/src/main/java/net/javacrumbs/shedlock/spring/aop/MethodProxyScheduledLockAdvisor.java
@@ -28,6 +28,7 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.AbstractPointcutAdvisor;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.core.SpringVersion;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;


### PR DESCRIPTION
When using ShedLock 4.x in a Spring Boot 1.5/Spring 4.3 application with InterceptMode.PROXY_METHOD, this fails with `NoSuchMethodError` due to usage of an `AnnotationMatchingPointcut` constructor that was added in Spring 5.0.0. 

It can easily be made to work by checking the Spring major version and using the appropriate constructor. With this fix, Spring 4.x-based applications should work again.
