### PR TITLE
Add Support for S3 as Lock Storage Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ import net.javacrumbs.shedlock.provider.s3.S3LockProvider;
 
 @Bean
 public LockProvider lockProvider(com.amazonaws.services.s3.AmazonS3 amazonS3) {
-    return new S3LockProvider(amazonS3, "BUKET_NAME");
+    return new S3LockProvider(amazonS3, "BUCKET_NAME");
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ executed repeatedly. Moreover, the locks are time-based and ShedLock assumes tha
   - [In-Memory](#in-memory)
   - [Memcached](#memcached-using-spymemcached)
   - [Datastore](#datastore)
+  - [S3](#s3)
 + [Multi-tenancy](#multi-tenancy)
 + [Customization](#customization)
 + [Duration specification](#duration-specification)
@@ -885,6 +886,28 @@ public LockProvider lockProvider(DatabaseClient databaseClient) {
 }
 ```
 
+#### S3
+
+Import the project
+```xml
+<dependency>
+    <groupId>net.javacrumbs.shedlock</groupId>
+    <artifactId>shedlock-provider-s3</artifactId>
+    <version>6.0.2</version>
+</dependency>
+```
+
+and configure
+```java
+import net.javacrumbs.shedlock.provider.s3.S3LockProvider;
+
+...
+
+@Bean
+public LockProvider lockProvider(com.amazonaws.services.s3.AmazonS3 amazonS3) {
+    return new S3LockProvider(amazonS3);
+}
+```
 
 ## Multi-tenancy
 If you have multi-tenancy use-case you can use a lock provider similar to this one

--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ import net.javacrumbs.shedlock.provider.s3.S3LockProvider;
 
 @Bean
 public LockProvider lockProvider(com.amazonaws.services.s3.AmazonS3 amazonS3) {
-    return new S3LockProvider(amazonS3);
+    return new S3LockProvider(amazonS3, "BUKET_NAME");
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <module>providers/datastore/shedlock-provider-datastore</module>
         <module>providers/spanner/shedlock-provider-spanner</module>
         <module>providers/neo4j/shedlock-provider-neo4j</module>
+        <module>providers/s3/shedlock-provider-s3</module>
     </modules>
 
     <properties>

--- a/providers/s3/shedlock-provider-s3/pom.xml
+++ b/providers/s3/shedlock-provider-s3/pom.xml
@@ -74,5 +74,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/providers/s3/shedlock-provider-s3/pom.xml
+++ b/providers/s3/shedlock-provider-s3/pom.xml
@@ -4,6 +4,7 @@
         <artifactId>shedlock-parent</artifactId>
         <groupId>net.javacrumbs.shedlock</groupId>
         <version>6.0.3-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/providers/s3/shedlock-provider-s3/pom.xml
+++ b/providers/s3/shedlock-provider-s3/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shedlock-parent</artifactId>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <version>6.0.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shedlock-provider-s3</artifactId>
+    <version>6.0.3-SNAPSHOT</version>
+
+    <properties>
+        <aws-java-sdk-s3.version>1.12.747</aws-java-sdk-s3.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws-java-sdk-s3.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${test-containers.ver}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <version>${test-containers.ver}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.ver}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.s3
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/providers/s3/shedlock-provider-s3/src/main/java/net/javacrumbs/shedlock/provider/s3/Lock.java
+++ b/providers/s3/shedlock-provider-s3/src/main/java/net/javacrumbs/shedlock/provider/s3/Lock.java
@@ -1,0 +1,5 @@
+package net.javacrumbs.shedlock.provider.s3;
+
+import java.time.Instant;
+
+record Lock(Instant lockUntil, Instant lockedAt, String lockedBy, String eTag) {}

--- a/providers/s3/shedlock-provider-s3/src/main/java/net/javacrumbs/shedlock/provider/s3/S3LockProvider.java
+++ b/providers/s3/shedlock-provider-s3/src/main/java/net/javacrumbs/shedlock/provider/s3/S3LockProvider.java
@@ -1,0 +1,31 @@
+package net.javacrumbs.shedlock.provider.s3;
+import com.amazonaws.services.s3.AmazonS3;
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+
+/**
+ * Lock provider implementation for S3.
+ */
+public class S3LockProvider extends StorageBasedLockProvider {
+
+    /**
+     * Constructs an S3LockProvider.
+     *
+     * @param s3Client   Amazon S3 client used to interact with the S3 bucket.
+     * @param bucketName The name of the S3 bucket where locks are stored.
+     * @param objectPrefix The prefix of the S3 object lock.
+     */
+    public S3LockProvider(AmazonS3 s3Client, String bucketName, String objectPrefix) {
+        super(new S3StorageAccessor(s3Client, bucketName, objectPrefix));
+    }
+
+    /**
+     * Constructs an S3LockProvider.
+     *
+     * @param s3Client   Amazon S3 client used to interact with the S3 bucket.
+     * @param bucketName The name of the S3 bucket where locks are stored.
+     */
+    public S3LockProvider(AmazonS3 s3Client, String bucketName) {
+        this(s3Client, bucketName, "shedlock/");
+    }
+}
+

--- a/providers/s3/shedlock-provider-s3/src/main/java/net/javacrumbs/shedlock/provider/s3/S3LockProvider.java
+++ b/providers/s3/shedlock-provider-s3/src/main/java/net/javacrumbs/shedlock/provider/s3/S3LockProvider.java
@@ -1,4 +1,5 @@
 package net.javacrumbs.shedlock.provider.s3;
+
 import com.amazonaws.services.s3.AmazonS3;
 import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
 
@@ -28,4 +29,3 @@ public class S3LockProvider extends StorageBasedLockProvider {
         this(s3Client, bucketName, "shedlock/");
     }
 }
-

--- a/providers/s3/shedlock-provider-s3/src/main/java/net/javacrumbs/shedlock/provider/s3/S3StorageAccessor.java
+++ b/providers/s3/shedlock-provider-s3/src/main/java/net/javacrumbs/shedlock/provider/s3/S3StorageAccessor.java
@@ -1,0 +1,167 @@
+package net.javacrumbs.shedlock.provider.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.support.AbstractStorageAccessor;
+
+import java.io.ByteArrayInputStream;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementation of StorageAccessor for S3 as a lock storage backend.
+ * Manages locks using S3 objects with metadata for expiration and conditional writes.
+ */
+public class S3StorageAccessor extends AbstractStorageAccessor {
+
+    private static final String LOCK_UNTIL = "lockUntil";
+    private static final String LOCKED_AT = "lockedAt";
+    private static final String LOCKED_BY = "lockedBy";
+
+    private final AmazonS3 s3Client;
+    private final String bucketName;
+    private final String objectPrefix;
+
+    public S3StorageAccessor(AmazonS3 s3Client, String bucketName, String objectPrefix) {
+        this.s3Client = s3Client;
+        this.bucketName = bucketName;
+        this.objectPrefix = objectPrefix;
+    }
+
+    /**
+     * Finds the lock in the S3 bucket.
+     */
+    Optional<Lock> find(String name, String action) {
+        try {
+            ObjectMetadata metadata = s3Client.getObjectMetadata(bucketName, objectName(name));
+            Instant lockUntil = Instant.parse(metadata.getUserMetaDataOf(LOCK_UNTIL));
+            Instant lockedAt = Instant.parse(metadata.getUserMetaDataOf(LOCKED_AT));
+            String lockedBy = metadata.getUserMetaDataOf(LOCKED_BY);
+            String eTag = metadata.getETag();
+
+            logger.debug("Lock found. action: {}, name: {}, lockUntil: {}, e-tag: {}", action, name, lockUntil, eTag);
+            return Optional.of(new Lock(lockUntil, lockedAt, lockedBy, eTag));
+        } catch (AmazonServiceException e) {
+            if (e.getStatusCode() == 404) {
+                logger.debug("Lock not found. action: {}, name: {}", action, name);
+                return Optional.empty();
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean insertRecord(LockConfiguration lockConfiguration) {
+        String name = lockConfiguration.getName();
+        if (find(name, "insertRecord").isPresent()) {
+            logger.debug("Lock already exists. name: {}", name);
+            return false;
+        }
+
+        try {
+            var lockContent = UUID.randomUUID().toString().getBytes();
+            ObjectMetadata metadata = createMetadata(lockConfiguration.getLockAtMostUntil(), ClockProvider.now(), getHostname());
+            metadata.setContentLength(lockContent.length);
+
+            PutObjectRequest request = new PutObjectRequest(
+                    bucketName, objectName(name), new ByteArrayInputStream(lockContent), metadata
+            );
+            request.putCustomRequestHeader("If-None-Match", "*");
+
+            s3Client.putObject(request);
+            logger.debug("Lock created successfully. name: {}, metadata: {}", name, metadata.getUserMetadata());
+            return true;
+        } catch (AmazonServiceException e) {
+            if (e.getStatusCode() == 412) {
+                logger.debug("Lock already in use. name: {}", name);
+            } else {
+                logger.warn("Failed to create lock. name: {}", name, e);
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean updateRecord(LockConfiguration lockConfiguration) {
+        Optional<Lock> lock = find(lockConfiguration.getName(), "updateRecord");
+        if (lock.isEmpty() || lock.get().lockUntil().isAfter(ClockProvider.now())) {
+            logger.debug("Update skipped. Lock still valid or not found. name: {}, lock: {}", lockConfiguration.getName(), lock);
+            return false;
+        }
+
+        ObjectMetadata newMetadata = createMetadata(lockConfiguration.getLockAtMostUntil(), ClockProvider.now(), getHostname());
+        return replaceObjectMetadata(lockConfiguration.getName(), newMetadata, lock.get().eTag(), "updateRecord");
+    }
+
+    @Override
+    public void unlock(LockConfiguration lockConfiguration) {
+        Optional<Lock> lock = find(lockConfiguration.getName(), "unlock");
+        if (lock.isEmpty()) {
+            logger.debug("Unlock skipped. Lock not found. name: {}, lock: {}", lockConfiguration.getName(), lock);
+            return;
+        }
+
+        updateUntil(lockConfiguration.getName(), lock.get(), lockConfiguration.getUnlockTime(), "unlock");
+    }
+
+    @Override
+    public boolean extend(LockConfiguration lockConfiguration) {
+        Optional<Lock> lock = find(lockConfiguration.getName(), "extend");
+        if (lock.isEmpty()
+                || lock.get().lockUntil().isBefore(ClockProvider.now())
+                || !lock.get().lockedBy().equals(getHostname())) {
+            logger.debug("Extend skipped. Lock invalid or not owned by host. name: {}, lock: {}", lockConfiguration.getName(), lock);
+            return false;
+        }
+
+        return updateUntil(lockConfiguration.getName(), lock.get(), lockConfiguration.getLockAtMostUntil(), "extend");
+    }
+
+    private boolean updateUntil(String name, Lock lock, Instant until, String action) {
+        ObjectMetadata existingMetadata = s3Client.getObjectMetadata(bucketName, objectName(name));
+        ObjectMetadata newMetadata = createMetadata(until, Instant.parse(existingMetadata.getUserMetaDataOf(LOCKED_AT)), getHostname());
+
+        return replaceObjectMetadata(name, newMetadata, lock.eTag(), action);
+    }
+
+    private boolean replaceObjectMetadata(String name, ObjectMetadata newMetadata, String eTag, String action) {
+        var lockContent = UUID.randomUUID().toString().getBytes();
+        newMetadata.setContentLength(lockContent.length);
+
+        PutObjectRequest request = new PutObjectRequest(
+                bucketName, objectName(name), new ByteArrayInputStream(lockContent), newMetadata
+        );
+        request.putCustomRequestHeader("If-Match", eTag);
+
+        try {
+            PutObjectResult response = s3Client.putObject(request);
+            logger.debug("Lock {} successfully. name: {}, old e-tag: {}, new e-tag: {}", action, name, eTag, response.getETag());
+            return true;
+        } catch (AmazonServiceException e) {
+            if (e.getStatusCode() == 412) {
+                logger.debug("Lock not exists to {}. name: {}, e-tag {}", action, name, eTag);
+            } else {
+                logger.warn("Failed to create lock. name: {}", name, e);
+            }
+            return false;
+        }
+    }
+
+    private ObjectMetadata createMetadata(Instant lockUntil, Instant lockedAt, String lockedBy) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.addUserMetadata(LOCK_UNTIL, lockUntil.toString());
+        metadata.addUserMetadata(LOCKED_AT, lockedAt.toString());
+        metadata.addUserMetadata(LOCKED_BY, lockedBy);
+        return metadata;
+    }
+
+    private String objectName(String name) {
+        return objectPrefix + name;
+    }
+}

--- a/providers/s3/shedlock-provider-s3/src/test/java/net/javacrumbs/shedlock/provider/s3/S3LockProviderIntegrationTest.java
+++ b/providers/s3/shedlock-provider-s3/src/test/java/net/javacrumbs/shedlock/provider/s3/S3LockProviderIntegrationTest.java
@@ -1,0 +1,91 @@
+package net.javacrumbs.shedlock.provider.s3;
+
+import static net.javacrumbs.shedlock.core.ClockProvider.now;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import net.javacrumbs.shedlock.test.support.AbstractStorageBasedLockProviderIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Integration test uses local instance of LocalStack S3 running on localhost at
+ * port 9042 using bucket shedlock and folder shedlock
+ *
+ * @see net.javacrumbs.shedlock.provider.s3.S3LockProvider
+ */
+@Testcontainers
+public class S3LockProviderIntegrationTest extends AbstractStorageBasedLockProviderIntegrationTest {
+
+    @Container
+    public static final MyLocalStackS3Container localStackS3 = new MyLocalStackS3Container();
+    private static AmazonS3 s3Client;
+    private static final String BUCKET_NAME = "my-bucket";
+    private static final String OBJECT_PREFIX = "prefix";
+
+    @BeforeAll
+    public static void startLocalStackS3() {
+        s3Client = AmazonS3ClientBuilder.standard().withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(localStackS3.getEndpoint().toString(), localStackS3.getRegion())
+        ).withCredentials(
+            new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(localStackS3.getAccessKey(), localStackS3.getSecretKey())
+            )
+        ).build();
+    }
+
+    @BeforeEach
+    public void before() {
+        s3Client.createBucket(BUCKET_NAME);
+    }
+
+    @AfterEach
+    public void after() {
+        s3Client.listObjects(BUCKET_NAME).getObjectSummaries().forEach(obj ->{
+            s3Client.deleteObject(BUCKET_NAME, obj.getKey());
+        });
+    }
+
+    @Override
+    protected StorageBasedLockProvider getLockProvider() {
+        return new S3LockProvider(s3Client, BUCKET_NAME, OBJECT_PREFIX);
+    }
+
+    @Override
+    protected void assertUnlocked(String lockName) {
+        Lock lock = findLock(lockName);
+        assertThat(lock.lockUntil()).isBefore(now());
+        assertThat(lock.lockedAt()).isBefore(now());
+        assertThat(lock.lockedBy()).isNotEmpty();
+    }
+
+    @Override
+    protected void assertLocked(String lockName) {
+        Lock lock = findLock(lockName);
+        assertThat(lock.lockUntil()).isAfter(now());
+        assertThat(lock.lockedAt()).isBefore(now());
+        assertThat(lock.lockedBy()).isNotEmpty();
+    }
+
+    private Lock findLock(String lockName) {
+        return new S3StorageAccessor(s3Client, BUCKET_NAME, OBJECT_PREFIX).find(lockName, "test").get();
+    }
+
+    private static class MyLocalStackS3Container extends LocalStackContainer {
+        public MyLocalStackS3Container() {
+            super(DockerImageName.parse("localstack/localstack:4.0.3"));
+        }
+    }
+}
+

--- a/providers/s3/shedlock-provider-s3/src/test/java/net/javacrumbs/shedlock/provider/s3/S3LockProviderIntegrationTest.java
+++ b/providers/s3/shedlock-provider-s3/src/test/java/net/javacrumbs/shedlock/provider/s3/S3LockProviderIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.javacrumbs.shedlock.provider.s3;
 
 import static net.javacrumbs.shedlock.core.ClockProvider.now;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -30,19 +29,19 @@ public class S3LockProviderIntegrationTest extends AbstractStorageBasedLockProvi
 
     @Container
     public static final MyLocalStackS3Container localStackS3 = new MyLocalStackS3Container();
+
     private static AmazonS3 s3Client;
     private static final String BUCKET_NAME = "my-bucket";
     private static final String OBJECT_PREFIX = "prefix";
 
     @BeforeAll
     public static void startLocalStackS3() {
-        s3Client = AmazonS3ClientBuilder.standard().withEndpointConfiguration(
-            new AwsClientBuilder.EndpointConfiguration(localStackS3.getEndpoint().toString(), localStackS3.getRegion())
-        ).withCredentials(
-            new AWSStaticCredentialsProvider(
-                new BasicAWSCredentials(localStackS3.getAccessKey(), localStackS3.getSecretKey())
-            )
-        ).build();
+        s3Client = AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
+                        localStackS3.getEndpoint().toString(), localStackS3.getRegion()))
+                .withCredentials(new AWSStaticCredentialsProvider(
+                        new BasicAWSCredentials(localStackS3.getAccessKey(), localStackS3.getSecretKey())))
+                .build();
     }
 
     @BeforeEach
@@ -52,7 +51,7 @@ public class S3LockProviderIntegrationTest extends AbstractStorageBasedLockProvi
 
     @AfterEach
     public void after() {
-        s3Client.listObjects(BUCKET_NAME).getObjectSummaries().forEach(obj ->{
+        s3Client.listObjects(BUCKET_NAME).getObjectSummaries().forEach(obj -> {
             s3Client.deleteObject(BUCKET_NAME, obj.getKey());
         });
     }
@@ -79,7 +78,9 @@ public class S3LockProviderIntegrationTest extends AbstractStorageBasedLockProvi
     }
 
     private Lock findLock(String lockName) {
-        return new S3StorageAccessor(s3Client, BUCKET_NAME, OBJECT_PREFIX).find(lockName, "test").get();
+        return new S3StorageAccessor(s3Client, BUCKET_NAME, OBJECT_PREFIX)
+                .find(lockName, "test")
+                .get();
     }
 
     private static class MyLocalStackS3Container extends LocalStackContainer {
@@ -88,4 +89,3 @@ public class S3LockProviderIntegrationTest extends AbstractStorageBasedLockProvi
         }
     }
 }
-

--- a/providers/s3/shedlock-provider-s3/src/test/resources/logback-test.xml
+++ b/providers/s3/shedlock-provider-s3/src/test/resources/logback-test.xml
@@ -1,0 +1,32 @@
+<!--
+
+    Copyright 2009 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="net.javacrumbs.shedlock.provider.s3" level="DEBUG" />
+    <logger name="net.javacrumbs.shedlock.test.support" level="DEBUG" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/shedlock-bom/pom.xml
+++ b/shedlock-bom/pom.xml
@@ -144,6 +144,11 @@
                 <artifactId>shedlock-provider-spanner</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>net.javacrumbs.shedlock</groupId>
+                <artifactId>shedlock-provider-s3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
**Description:**
This pull request introduces support for using Amazon S3 as a lock storage backend for ShedLock, leveraging S3's recently introduced conditional writes for concurrency control.

**Motivation:**
The addition of S3 as a lock storage backend allows users to take advantage of Amazon S3's scalability, availability, and now its conditional write operations. This makes S3 a compelling choice for distributed lock management in environments where S3 is already utilized.

https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-s3-functionality-conditional-writes/
https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html
