### PR TITLE
Add shedlock-provider-jdbc to bom

### DIFF
--- a/shedlock-bom/pom.xml
+++ b/shedlock-bom/pom.xml
@@ -51,6 +51,11 @@
             </dependency>
             <dependency>
                 <groupId>net.javacrumbs.shedlock</groupId>
+                <artifactId>shedlock-provider-jdbc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.javacrumbs.shedlock</groupId>
                 <artifactId>shedlock-provider-jooq</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Hi,
we realized that shedlock-provider-jdbc was missing in the bom. I hope it's fine that I just opened a PR without creating an issue first as this is a very small and trivial change.