### PR TITLE
Fix for #2583

### DIFF
--- a/providers/redis/shedlock-provider-redis-jedis4/pom.xml
+++ b/providers/redis/shedlock-provider-redis-jedis4/pom.xml
@@ -24,12 +24,6 @@
             <version>5.2.0</version>
         </dependency>
 
-        <dependency>
-            <groupId>net.javacrumbs.shedlock</groupId>
-            <artifactId>shedlock-test-support</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>

--- a/providers/redis/shedlock-provider-redis-jedis4/src/test/java/net/javacrumbs/shedlock/provider/redis/jedis4/JedisLockProviderIntegrationTest.java
+++ b/providers/redis/shedlock-provider-redis-jedis4/src/test/java/net/javacrumbs/shedlock/provider/redis/jedis4/JedisLockProviderIntegrationTest.java
@@ -18,8 +18,8 @@ import static net.javacrumbs.shedlock.provider.redis.testsupport.RedisContainer.
 import static org.assertj.core.api.Assertions.assertThat;
 
 import net.javacrumbs.shedlock.core.ExtensibleLockProvider;
+import net.javacrumbs.shedlock.provider.redis.testsupport.AbstractExtensibleLockProviderRedisIntegrationTest;
 import net.javacrumbs.shedlock.provider.redis.testsupport.RedisContainer;
-import net.javacrumbs.shedlock.test.support.AbstractExtensibleLockProviderIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.testcontainers.junit.jupiter.Container;
@@ -36,7 +36,7 @@ public class JedisLockProviderIntegrationTest {
     public static final RedisContainer redis = new RedisContainer(PORT);
 
     @Nested
-    class Cluster extends AbstractExtensibleLockProviderIntegrationTest {
+    class Cluster extends AbstractExtensibleLockProviderRedisIntegrationTest {
         private ExtensibleLockProvider lockProvider;
 
         private JedisCluster jedisCluster;
@@ -68,7 +68,7 @@ public class JedisLockProviderIntegrationTest {
     }
 
     @Nested
-    class Pool extends AbstractExtensibleLockProviderIntegrationTest {
+    class Pool extends AbstractExtensibleLockProviderRedisIntegrationTest {
         private ExtensibleLockProvider lockProvider;
 
         private JedisPool jedisPool;

--- a/providers/redis/shedlock-provider-redis-lettuce/pom.xml
+++ b/providers/redis/shedlock-provider-redis-lettuce/pom.xml
@@ -26,13 +26,6 @@
 
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
-            <artifactId>shedlock-test-support</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-test-support-redis</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/providers/redis/shedlock-provider-redis-lettuce/src/main/java/net/javacrumbs/shedlock/provider/redis/lettuce/LettuceLockProvider.java
+++ b/providers/redis/shedlock-provider-redis-lettuce/src/main/java/net/javacrumbs/shedlock/provider/redis/lettuce/LettuceLockProvider.java
@@ -16,11 +16,13 @@ package net.javacrumbs.shedlock.provider.redis.lettuce;
 import static net.javacrumbs.shedlock.support.Utils.getHostname;
 import static net.javacrumbs.shedlock.support.Utils.toIsoString;
 
+import io.lettuce.core.ScriptOutputType;
 import io.lettuce.core.SetArgs;
 import io.lettuce.core.api.StatefulRedisConnection;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 import net.javacrumbs.shedlock.core.AbstractSimpleLock;
 import net.javacrumbs.shedlock.core.ClockProvider;
 import net.javacrumbs.shedlock.core.ExtensibleLockProvider;
@@ -40,6 +42,27 @@ public class LettuceLockProvider implements ExtensibleLockProvider {
 
     private static final String KEY_PREFIX = "job-lock";
     private static final String ENV_DEFAULT = "default";
+
+    /*
+     * https://redis.io/docs/latest/develop/use/patterns/distributed-locks/
+     * */
+    private static final String delLuaScript =
+            """
+        if redis.call("get",KEYS[1]) == ARGV[1] then
+            return redis.call("del",KEYS[1])
+        else
+            return 0
+        end
+        """;
+
+    private static final String updLuaScript =
+            """
+        if redis.call('get', KEYS[1]) == ARGV[1] then
+           return redis.call('pexpire', KEYS[1], ARGV[2])
+        else
+           return 0
+        end
+        """;
 
     private final StatefulRedisConnection<String, String> connection;
     private final String environment;
@@ -68,12 +91,13 @@ public class LettuceLockProvider implements ExtensibleLockProvider {
         long expireTime = getMsUntil(lockConfiguration.getLockAtMostUntil());
 
         String key = buildKey(lockConfiguration.getName(), environment);
+        String uniqueValue = buildValue();
 
         String rez =
-                connection.sync().set(key, buildValue(), SetArgs.Builder.nx().px(expireTime));
+                connection.sync().set(key, uniqueValue, SetArgs.Builder.nx().px(expireTime));
 
         if ("OK".equals(rez)) {
-            return Optional.of(new RedisLock(key, connection, lockConfiguration));
+            return Optional.of(new RedisLock(key, uniqueValue, connection, lockConfiguration));
         }
 
         return Optional.empty();
@@ -82,12 +106,17 @@ public class LettuceLockProvider implements ExtensibleLockProvider {
     private static final class RedisLock extends AbstractSimpleLock {
 
         private final String key;
+        private final String value;
         private final StatefulRedisConnection<String, String> connection;
 
         private RedisLock(
-                String key, StatefulRedisConnection<String, String> connection, LockConfiguration lockConfiguration) {
+                String key,
+                String value,
+                StatefulRedisConnection<String, String> connection,
+                LockConfiguration lockConfiguration) {
             super(lockConfiguration);
             this.key = key;
+            this.value = value;
             this.connection = connection;
         }
 
@@ -98,12 +127,14 @@ public class LettuceLockProvider implements ExtensibleLockProvider {
             // lock at least until is in the past
             if (keepLockFor <= 0) {
                 try {
-                    connection.sync().del(key);
+                    connection
+                            .sync()
+                            .eval(delLuaScript, ScriptOutputType.INTEGER, new String[] {key}, new String[] {value});
                 } catch (Exception e) {
                     throw new LockException("Can not remove node", e);
                 }
             } else {
-                connection.sync().set(key, buildValue(), SetArgs.Builder.xx().px(keepLockFor));
+                LettuceLockProvider.extend(this, keepLockFor);
             }
         }
 
@@ -112,12 +143,8 @@ public class LettuceLockProvider implements ExtensibleLockProvider {
         protected Optional<SimpleLock> doExtend(@NonNull LockConfiguration newConfiguration) {
             long expiryMs = getMsUntil(newConfiguration.getLockAtMostUntil());
 
-            String result = connection
-                    .sync()
-                    .set(key, buildValue(), SetArgs.Builder.xx().px(expiryMs));
-
-            if ("OK".equals(result)) {
-                return Optional.of(new RedisLock(key, connection, newConfiguration));
+            if (LettuceLockProvider.extend(this, expiryMs)) {
+                return Optional.of(new RedisLock(key, value, connection, newConfiguration));
             }
 
             return Optional.empty();
@@ -133,6 +160,18 @@ public class LettuceLockProvider implements ExtensibleLockProvider {
     }
 
     private static String buildValue() {
-        return String.format("ADDED:%s@%s", toIsoString(ClockProvider.now()), getHostname());
+        return String.format("ADDED:%s@%s:%s", toIsoString(ClockProvider.now()), getHostname(), UUID.randomUUID());
+    }
+
+    private static boolean extend(RedisLock lock, long expiryMs) {
+        return lock.connection
+                .sync()
+                .eval(
+                        updLuaScript,
+                        ScriptOutputType.INTEGER,
+                        new String[] {lock.key},
+                        lock.value,
+                        String.valueOf(expiryMs))
+                .equals(1L);
     }
 }

--- a/providers/redis/shedlock-provider-redis-lettuce/src/test/java/net/javacrumbs/shedlock/provider/redis/lettuce/LettuceLockProviderIntegrationTest.java
+++ b/providers/redis/shedlock-provider-redis-lettuce/src/test/java/net/javacrumbs/shedlock/provider/redis/lettuce/LettuceLockProviderIntegrationTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;
 import net.javacrumbs.shedlock.core.ExtensibleLockProvider;
+import net.javacrumbs.shedlock.provider.redis.testsupport.AbstractExtensibleLockProviderRedisIntegrationTest;
 import net.javacrumbs.shedlock.provider.redis.testsupport.RedisContainer;
-import net.javacrumbs.shedlock.test.support.AbstractExtensibleLockProviderIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.testcontainers.junit.jupiter.Container;
@@ -39,7 +39,7 @@ public class LettuceLockProviderIntegrationTest {
     }
 
     @Nested
-    class Cluster extends AbstractExtensibleLockProviderIntegrationTest {
+    class Cluster extends AbstractExtensibleLockProviderRedisIntegrationTest {
 
         private ExtensibleLockProvider lockProvider;
         private StatefulRedisConnection<String, String> connection;
@@ -71,7 +71,7 @@ public class LettuceLockProviderIntegrationTest {
     }
 
     @Nested
-    class Pool extends AbstractExtensibleLockProviderIntegrationTest {
+    class Pool extends AbstractExtensibleLockProviderRedisIntegrationTest {
 
         private ExtensibleLockProvider lockProvider;
         private StatefulRedisConnection<String, String> connection;

--- a/providers/redis/shedlock-provider-redis-spring/pom.xml
+++ b/providers/redis/shedlock-provider-redis-spring/pom.xml
@@ -31,12 +31,6 @@
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>net.javacrumbs.shedlock</groupId>
-            <artifactId>shedlock-test-support</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>

--- a/providers/redis/shedlock-provider-redis-spring/src/test/java/net/javacrumbs/shedlock/provider/redis/spring/AbstractRedisLockProviderIntegrationTest.java
+++ b/providers/redis/shedlock-provider-redis-spring/src/test/java/net/javacrumbs/shedlock/provider/redis/spring/AbstractRedisLockProviderIntegrationTest.java
@@ -16,11 +16,12 @@ package net.javacrumbs.shedlock.provider.redis.spring;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import net.javacrumbs.shedlock.core.ExtensibleLockProvider;
-import net.javacrumbs.shedlock.test.support.AbstractExtensibleLockProviderIntegrationTest;
+import net.javacrumbs.shedlock.provider.redis.testsupport.AbstractExtensibleLockProviderRedisIntegrationTest;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
-public abstract class AbstractRedisLockProviderIntegrationTest extends AbstractExtensibleLockProviderIntegrationTest {
+public abstract class AbstractRedisLockProviderIntegrationTest
+        extends AbstractExtensibleLockProviderRedisIntegrationTest {
 
     private final RedisLockProvider lockProvider;
     private final StringRedisTemplate redisTemplate;

--- a/providers/redis/shedlock-provider-redis-spring/src/test/java/net/javacrumbs/shedlock/provider/redis/spring/SpringRedisLockProviderIntegrationTest.java
+++ b/providers/redis/shedlock-provider-redis-spring/src/test/java/net/javacrumbs/shedlock/provider/redis/spring/SpringRedisLockProviderIntegrationTest.java
@@ -47,15 +47,15 @@ public class SpringRedisLockProviderIntegrationTest {
     }
 
     @Nested
-    class Letucce extends AbstractRedisLockProviderIntegrationTest {
-        public Letucce() {
+    class Lettuce extends AbstractRedisLockProviderIntegrationTest {
+        public Lettuce() {
             super(createLettuceConnectionFactory());
         }
     }
 
     @Nested
-    class ReactiveLetucce extends AbstractReactiveRedisLockProviderIntegrationTest {
-        public ReactiveLetucce() {
+    class ReactiveLettuce extends AbstractReactiveRedisLockProviderIntegrationTest {
+        public ReactiveLettuce() {
             super(createLettuceConnectionFactory());
         }
     }

--- a/providers/redis/shedlock-test-support-redis/pom.xml
+++ b/providers/redis/shedlock-test-support-redis/pom.xml
@@ -12,6 +12,13 @@
     <version>6.6.2-SNAPSHOT</version>
 
     <dependencies>
+
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.playtika.testcontainers</groupId>
             <artifactId>embedded-redis</artifactId>

--- a/providers/redis/shedlock-test-support-redis/src/main/java/net/javacrumbs/shedlock/provider/redis/testsupport/AbstractExtensibleLockProviderRedisIntegrationTest.java
+++ b/providers/redis/shedlock-test-support-redis/src/main/java/net/javacrumbs/shedlock/provider/redis/testsupport/AbstractExtensibleLockProviderRedisIntegrationTest.java
@@ -1,0 +1,37 @@
+package net.javacrumbs.shedlock.provider.redis.testsupport;
+
+import static java.time.Duration.ZERO;
+import static java.time.Duration.ofSeconds;
+
+import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.test.support.AbstractExtensibleLockProviderIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The fix for this use-case only exists in Redis LockProvider implementations.
+ * When we will fix this in all LockProviders, we can move this test to the base class, removing the need for this class.
+ */
+public abstract class AbstractExtensibleLockProviderRedisIntegrationTest
+        extends AbstractExtensibleLockProviderIntegrationTest {
+
+    @Test
+    public void unlockingAfterExpirationShouldBeNoOp() {
+        int lockDurationSeconds = 2;
+        SimpleLock lock1 = lock(ofSeconds(lockDurationSeconds));
+        sleepFor(ofSeconds(lockDurationSeconds + 1));
+        SimpleLock lock2 = lock(ofSeconds(lockDurationSeconds));
+        lock1.unlock();
+        assertLocked(LOCK_NAME1);
+    }
+
+    @Test
+    public void extendAfterExpirationShouldBeNoOp() {
+        int lockDurationSeconds = 2;
+        SimpleLock lock1 = lock(ofSeconds(lockDurationSeconds));
+        sleepFor(ofSeconds(lockDurationSeconds + 1));
+        SimpleLock lock2 = lock(ofSeconds(lockDurationSeconds));
+        lock1.extend(ofSeconds(lockDurationSeconds * 5), ZERO);
+        sleepFor(ofSeconds(lockDurationSeconds + 1));
+        assertUnlocked(LOCK_NAME1);
+    }
+}

--- a/shedlock-test-support/src/main/java/net/javacrumbs/shedlock/test/support/AbstractExtensibleLockProviderIntegrationTest.java
+++ b/shedlock-test-support/src/main/java/net/javacrumbs/shedlock/test/support/AbstractExtensibleLockProviderIntegrationTest.java
@@ -111,7 +111,7 @@ public abstract class AbstractExtensibleLockProviderIntegrationTest extends Abst
         return newLock.get();
     }
 
-    private SimpleLock lock(Duration lockAtMostFor) {
+    protected SimpleLock lock(Duration lockAtMostFor) {
         Optional<SimpleLock> lock = getLockProvider().lock(lockConfig(LOCK_NAME1, lockAtMostFor, ZERO));
         assertThat(lock).isNotEmpty();
         assertLocked(LOCK_NAME1);


### PR DESCRIPTION
Implement Redis distributed locking respecting unique lock value to avoid removing a lock that was created by another client. (https://redis.io/docs/latest/develop/use/patterns/distributed-locks/)