### PR TITLE
Add exposed provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>providers/jdbc/shedlock-provider-jdbc-internal</module>
         <module>providers/jdbc/shedlock-provider-jdbc</module>
         <module>providers/jdbc/shedlock-provider-jooq</module>
+        <module>providers/jdbc/shedlock-provider-exposed</module>
         <module>providers/jdbc/shedlock-provider-jdbc-template</module>
         <module>providers/jdbc/shedlock-provider-jdbc-micronaut</module>
         <module>providers/r2dbc/shedlock-provider-r2dbc</module>

--- a/providers/jdbc/shedlock-provider-exposed/pom.xml
+++ b/providers/jdbc/shedlock-provider-exposed/pom.xml
@@ -101,8 +101,22 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>17</jvmTarget>
+                    <jvmTarget>${jdk.version}</jvmTarget>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>javadocJar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/providers/jdbc/shedlock-provider-exposed/pom.xml
+++ b/providers/jdbc/shedlock-provider-exposed/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shedlock-parent</artifactId>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <version>6.8.1-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shedlock-provider-exposed</artifactId>
+    <version>6.8.1-SNAPSHOT</version>
+
+    <properties>
+        <kotlin.version>2.1.0</kotlin.version>
+        <exposed.version>0.61.0</exposed.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Kotlin 의존성 -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.exposed</groupId>
+            <artifactId>exposed-core</artifactId>
+            <version>${exposed.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.exposed</groupId>
+            <artifactId>exposed-dao</artifactId>
+            <version>${exposed.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.exposed</groupId>
+            <artifactId>exposed-jdbc</artifactId>
+            <version>${exposed.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.exposed</groupId>
+            <artifactId>exposed-java-time</artifactId>
+            <version>${exposed.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support-jdbc</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.ver}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.ver}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>17</jvmTarget>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.exposed
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/providers/jdbc/shedlock-provider-exposed/pom.xml
+++ b/providers/jdbc/shedlock-provider-exposed/pom.xml
@@ -23,7 +23,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Kotlin 의존성 -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
@@ -1,0 +1,23 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.QueryBuilder
+import java.time.Duration
+import java.time.LocalDateTime
+
+internal fun Expression<LocalDateTime>.plus(duration: Duration): Expression<LocalDateTime> =
+        IntervalExpression(this, duration.seconds)
+
+private class IntervalExpression(
+        private val expression: Expression<LocalDateTime>,
+        private val seconds: Long
+) : Expression<LocalDateTime>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder.let {
+            it.append("(")
+            expression.toQueryBuilder(queryBuilder)
+            it.append(" + INTERVAL '${seconds}' SECOND")
+            it.append(")")
+        }
+    }
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
@@ -16,8 +16,11 @@ private class IntervalExpression(private val expression: Expression<LocalDateTim
         when (currentDialect) {
             is SQLServerDialect -> {
                 queryBuilder.run {
+                    // Subtract 1 millisecond to address precision issues in SQL Server datetime comparison
+                    val precisionAdjustedMillis = duration.toMillis() - 1
+
                     append("(DATEADD(millisecond, ")
-                    append(duration.toMillis().toString())
+                    append(precisionAdjustedMillis.toString())
                     append(", ")
                     expression.toQueryBuilder(queryBuilder)
                     append("))")

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
@@ -27,7 +27,7 @@ private class IntervalExpression(private val expression: Expression<LocalDateTim
                 queryBuilder.run {
                     append("(")
                     expression.toQueryBuilder(queryBuilder)
-                    append(" + INTERVAL '${duration.seconds}' SECOND")
+                    append(" + INTERVAL '${duration.toMillis() / 1000.0}' SECOND")
                     append(")")
                 }
             }

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
@@ -16,7 +16,8 @@ private class IntervalExpression(private val expression: Expression<LocalDateTim
         when (currentDialect) {
             is SQLServerDialect -> {
                 queryBuilder.run {
-                    // Subtract 1 millisecond to address precision issues in SQL Server datetime comparison
+                    // SQL Server uses millisecond precision in datetime comparisons
+                    // Adding a small buffer (1ms less) to ensure time comparison behaves as expected
                     val precisionAdjustedMillis = duration.toMillis() - 1
 
                     append("(DATEADD(millisecond, ")

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
@@ -17,20 +17,20 @@ private class IntervalExpression(
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         when(currentDialect) {
             is SQLServerDialect -> {
-                queryBuilder.let {
-                    it.append("(DATEADD(millisecond, ")
-                    it.append(duration.toMillis().toString())
-                    it.append(", ")
+                queryBuilder.run {
+                    append("(DATEADD(millisecond, ")
+                    append(duration.toMillis().toString())
+                    append(", ")
                     expression.toQueryBuilder(queryBuilder)
-                    it.append("))")
+                    append("))")
                 }
             }
             else -> {
-                queryBuilder.let {
-                    it.append("(")
+                queryBuilder.run {
+                    append("(")
                     expression.toQueryBuilder(queryBuilder)
-                    it.append(" + INTERVAL '${duration.seconds}' SECOND")
-                    it.append(")")
+                    append(" + INTERVAL '${duration.seconds}' SECOND")
+                    append(")")
                 }
             }
         }

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
@@ -2,22 +2,37 @@ package net.javacrumbs.shedlock.provider.exposed
 
 import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.QueryBuilder
+import org.jetbrains.exposed.sql.vendors.SQLServerDialect
+import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.time.Duration
 import java.time.LocalDateTime
 
 internal fun Expression<LocalDateTime>.plus(duration: Duration): Expression<LocalDateTime> =
-        IntervalExpression(this, duration.seconds)
+        IntervalExpression(this, duration)
 
 private class IntervalExpression(
         private val expression: Expression<LocalDateTime>,
-        private val seconds: Long
+        private val duration: Duration
 ) : Expression<LocalDateTime>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        queryBuilder.let {
-            it.append("(")
-            expression.toQueryBuilder(queryBuilder)
-            it.append(" + INTERVAL '${seconds}' SECOND")
-            it.append(")")
+        when(currentDialect) {
+            is SQLServerDialect -> {
+                queryBuilder.let {
+                    it.append("(DATEADD(millisecond, ")
+                    it.append(duration.toMillis().toString())
+                    it.append(", ")
+                    expression.toQueryBuilder(queryBuilder)
+                    it.append("))")
+                }
+            }
+            else -> {
+                queryBuilder.let {
+                    it.append("(")
+                    expression.toQueryBuilder(queryBuilder)
+                    it.append(" + INTERVAL '${duration.seconds}' SECOND")
+                    it.append(")")
+                }
+            }
         }
     }
 }

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
@@ -1,21 +1,19 @@
 package net.javacrumbs.shedlock.provider.exposed
 
+import java.time.Duration
+import java.time.LocalDateTime
 import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
-import java.time.Duration
-import java.time.LocalDateTime
 
 internal fun Expression<LocalDateTime>.plus(duration: Duration): Expression<LocalDateTime> =
-        IntervalExpression(this, duration)
+    IntervalExpression(this, duration)
 
-private class IntervalExpression(
-        private val expression: Expression<LocalDateTime>,
-        private val duration: Duration
-) : Expression<LocalDateTime>() {
+private class IntervalExpression(private val expression: Expression<LocalDateTime>, private val duration: Duration) :
+    Expression<LocalDateTime>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        when(currentDialect) {
+        when (currentDialect) {
             is SQLServerDialect -> {
                 queryBuilder.run {
                     append("(DATEADD(millisecond, ")

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedLockProvider.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedLockProvider.kt
@@ -1,0 +1,8 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider
+import org.jetbrains.exposed.sql.Database
+
+class ExposedLockProvider(
+        database: Database
+) : StorageBasedLockProvider(ExposedStorageAccessor(database))

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedLockProvider.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedLockProvider.kt
@@ -3,6 +3,4 @@ package net.javacrumbs.shedlock.provider.exposed
 import net.javacrumbs.shedlock.support.StorageBasedLockProvider
 import org.jetbrains.exposed.sql.Database
 
-class ExposedLockProvider(
-        database: Database
-) : StorageBasedLockProvider(ExposedStorageAccessor(database))
+class ExposedLockProvider(database: Database) : StorageBasedLockProvider(ExposedStorageAccessor(database))

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
@@ -1,5 +1,7 @@
 package net.javacrumbs.shedlock.provider.exposed
 
+import java.time.Duration
+import java.time.LocalDateTime
 import net.javacrumbs.shedlock.core.LockConfiguration
 import net.javacrumbs.shedlock.support.AbstractStorageAccessor
 import org.jetbrains.exposed.sql.Case
@@ -11,68 +13,55 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.javatime.CurrentDateTime
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
-import java.time.Duration
-import java.time.LocalDateTime
 
-class ExposedStorageAccessor(
-        private val database: Database
-) : AbstractStorageAccessor() {
+class ExposedStorageAccessor(private val database: Database) : AbstractStorageAccessor() {
 
     private val now: Expression<LocalDateTime> = CurrentDateTime
 
     override fun insertRecord(lockConfiguration: LockConfiguration): Boolean =
-            transaction(database) {
-                try {
-                    Shedlock.insert {
-                        it[name] = lockConfiguration.name
-                        it[lockUntil] = nowPlus(lockConfiguration.lockAtMostFor)
-                        it[lockedAt] = now
-                        it[lockedBy] = hostname
-                    }
-                    true
-                } catch (_: Exception) {
-                    false
-                }
-            }
-
-
-    override fun updateRecord(lockConfiguration: LockConfiguration): Boolean =
-            transaction(database) {
-                Shedlock.update({
-                    (Shedlock.name eq lockConfiguration.name) and
-                            (Shedlock.lockUntil lessEq now)
-                }) {
+        transaction(database) {
+            try {
+                Shedlock.insert {
+                    it[name] = lockConfiguration.name
                     it[lockUntil] = nowPlus(lockConfiguration.lockAtMostFor)
                     it[lockedAt] = now
                     it[lockedBy] = hostname
-                } > 0
+                }
+                true
+            } catch (_: Exception) {
+                false
             }
+        }
+
+    override fun updateRecord(lockConfiguration: LockConfiguration): Boolean =
+        transaction(database) {
+            Shedlock.update({ (Shedlock.name eq lockConfiguration.name) and (Shedlock.lockUntil lessEq now) }) {
+                it[lockUntil] = nowPlus(lockConfiguration.lockAtMostFor)
+                it[lockedAt] = now
+                it[lockedBy] = hostname
+            } > 0
+        }
 
     override fun unlock(lockConfiguration: LockConfiguration) {
         transaction(database) {
             val lockAtLeastUntil = Shedlock.lockedAt.plus(lockConfiguration.lockAtLeastFor)
 
-            Shedlock.update({
-                (Shedlock.name eq lockConfiguration.name) and
-                        (Shedlock.lockedBy eq hostname)
-            }) {
-                it[lockUntil] = Case()
-                        .When(lockAtLeastUntil greater now, lockAtLeastUntil)
-                        .Else(now)
+            Shedlock.update({ (Shedlock.name eq lockConfiguration.name) and (Shedlock.lockedBy eq hostname) }) {
+                it[lockUntil] = Case().When(lockAtLeastUntil greater now, lockAtLeastUntil).Else(now)
             }
         }
     }
 
     override fun extend(lockConfiguration: LockConfiguration): Boolean =
-            transaction(database) {
-                Shedlock.update({
-                    (Shedlock.name eq lockConfiguration.name) and
-                            (Shedlock.lockedBy eq hostname) and
-                            (Shedlock.lockUntil greater now)
-                }) {
-                    it[lockUntil] = nowPlus(lockConfiguration.lockAtMostFor)
-                } > 0
-            }
+        transaction(database) {
+            Shedlock.update({
+                (Shedlock.name eq lockConfiguration.name) and
+                    (Shedlock.lockedBy eq hostname) and
+                    (Shedlock.lockUntil greater now)
+            }) {
+                it[lockUntil] = nowPlus(lockConfiguration.lockAtMostFor)
+            } > 0
+        }
 
     private fun nowPlus(duration: Duration): Expression<LocalDateTime> = now.plus(duration)
 }

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
@@ -1,7 +1,5 @@
 package net.javacrumbs.shedlock.provider.exposed
 
-import java.time.Duration
-import java.time.LocalDateTime
 import net.javacrumbs.shedlock.core.LockConfiguration
 import net.javacrumbs.shedlock.support.AbstractStorageAccessor
 import org.jetbrains.exposed.sql.Case
@@ -13,6 +11,8 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.javatime.CurrentDateTime
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
+import java.time.Duration
+import java.time.LocalDateTime
 
 internal class ExposedStorageAccessor(private val database: Database) : AbstractStorageAccessor() {
 
@@ -28,7 +28,9 @@ internal class ExposedStorageAccessor(private val database: Database) : Abstract
                     it[lockedBy] = hostname
                 }
                 true
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                logger.debug("Exception thrown when inserting record", e);
+
                 false
             }
         }

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
@@ -14,7 +14,7 @@ import org.jetbrains.exposed.sql.javatime.CurrentDateTime
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 
-class ExposedStorageAccessor(private val database: Database) : AbstractStorageAccessor() {
+internal class ExposedStorageAccessor(private val database: Database) : AbstractStorageAccessor() {
 
     private val now: Expression<LocalDateTime> = CurrentDateTime
 

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
@@ -1,5 +1,7 @@
 package net.javacrumbs.shedlock.provider.exposed
 
+import java.time.Duration
+import java.time.LocalDateTime
 import net.javacrumbs.shedlock.core.LockConfiguration
 import net.javacrumbs.shedlock.support.AbstractStorageAccessor
 import org.jetbrains.exposed.sql.Case
@@ -11,8 +13,6 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.javatime.CurrentDateTime
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
-import java.time.Duration
-import java.time.LocalDateTime
 
 internal class ExposedStorageAccessor(private val database: Database) : AbstractStorageAccessor() {
 
@@ -29,7 +29,7 @@ internal class ExposedStorageAccessor(private val database: Database) : Abstract
                 }
                 true
             } catch (e: Exception) {
-                logger.debug("Exception thrown when inserting record", e);
+                logger.debug("Exception thrown when inserting record", e)
 
                 false
             }

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedStorageAccessor.kt
@@ -1,0 +1,78 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import net.javacrumbs.shedlock.core.LockConfiguration
+import net.javacrumbs.shedlock.support.AbstractStorageAccessor
+import org.jetbrains.exposed.sql.Case
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import java.time.Duration
+import java.time.LocalDateTime
+
+class ExposedStorageAccessor(
+        private val database: Database
+) : AbstractStorageAccessor() {
+
+    private val now: Expression<LocalDateTime> = CurrentDateTime
+
+    override fun insertRecord(lockConfiguration: LockConfiguration): Boolean =
+            transaction(database) {
+                try {
+                    Shedlock.insert {
+                        it[name] = lockConfiguration.name
+                        it[lockUntil] = nowPlus(lockConfiguration.lockAtMostFor)
+                        it[lockedAt] = now
+                        it[lockedBy] = hostname
+                    }
+                    true
+                } catch (_: Exception) {
+                    false
+                }
+            }
+
+
+    override fun updateRecord(lockConfiguration: LockConfiguration): Boolean =
+            transaction(database) {
+                Shedlock.update({
+                    (Shedlock.name eq lockConfiguration.name) and
+                            (Shedlock.lockUntil lessEq now)
+                }) {
+                    it[lockUntil] = nowPlus(lockConfiguration.lockAtMostFor)
+                    it[lockedAt] = now
+                    it[lockedBy] = hostname
+                } > 0
+            }
+
+    override fun unlock(lockConfiguration: LockConfiguration) {
+        transaction(database) {
+            val lockAtLeastUntil = Shedlock.lockedAt.plus(lockConfiguration.lockAtLeastFor)
+
+            Shedlock.update({
+                (Shedlock.name eq lockConfiguration.name) and
+                        (Shedlock.lockedBy eq hostname)
+            }) {
+                it[lockUntil] = Case()
+                        .When(lockAtLeastUntil greater now, lockAtLeastUntil)
+                        .Else(now)
+            }
+        }
+    }
+
+    override fun extend(lockConfiguration: LockConfiguration): Boolean =
+            transaction(database) {
+                Shedlock.update({
+                    (Shedlock.name eq lockConfiguration.name) and
+                            (Shedlock.lockedBy eq hostname) and
+                            (Shedlock.lockUntil greater now)
+                }) {
+                    it[lockUntil] = nowPlus(lockConfiguration.lockAtMostFor)
+                } > 0
+            }
+
+    private fun nowPlus(duration: Duration): Expression<LocalDateTime> = now.plus(duration)
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/Shedlock.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/Shedlock.kt
@@ -3,7 +3,7 @@ package net.javacrumbs.shedlock.provider.exposed
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.javatime.datetime
 
-object Shedlock : Table() {
+internal object Shedlock : Table() {
     override val tableName: String = "shedlock"
     val name = varchar("name", 64)
     val lockUntil = datetime("lock_until")

--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/Shedlock.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/Shedlock.kt
@@ -1,0 +1,14 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.javatime.datetime
+
+object Shedlock : Table() {
+    override val tableName: String = "shedlock"
+    val name = varchar("name", 64)
+    val lockUntil = datetime("lock_until")
+    val lockedAt = datetime("locked_at")
+    val lockedBy = varchar("locked_by", 255)
+
+    override val primaryKey = PrimaryKey(name)
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/AbstractExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/AbstractExposedLockProviderIntegrationTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 @TestInstance(PER_CLASS)
 abstract class AbstractExposedLockProviderIntegrationTest(
     private val dvConfig: DbConfig,
-    private val database: Database
+    private val database: Database,
 ) : AbstractJdbcLockProviderIntegrationTest() {
 
     override fun getDbConfig(): DbConfig = dvConfig

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/AbstractExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/AbstractExposedLockProviderIntegrationTest.kt
@@ -1,0 +1,33 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider
+import net.javacrumbs.shedlock.test.support.jdbc.AbstractJdbcLockProviderIntegrationTest
+import net.javacrumbs.shedlock.test.support.jdbc.DbConfig
+import org.jetbrains.exposed.sql.Database
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+
+@TestInstance(PER_CLASS)
+abstract class AbstractExposedLockProviderIntegrationTest(
+    private val dvConfig: DbConfig,
+    private val database: Database
+) : AbstractJdbcLockProviderIntegrationTest() {
+
+    override fun getDbConfig(): DbConfig = dvConfig
+
+    override fun useDbTime(): Boolean = true
+
+    override fun getLockProvider(): StorageBasedLockProvider = ExposedLockProvider(database)
+
+    @BeforeAll
+    fun startDb() {
+        dbConfig.startDb()
+    }
+
+    @AfterAll
+    fun shutdownDb() {
+        dbConfig.shutdownDb()
+    }
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/AbstractExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/AbstractExposedLockProviderIntegrationTest.kt
@@ -11,11 +11,11 @@ import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 
 @TestInstance(PER_CLASS)
 abstract class AbstractExposedLockProviderIntegrationTest(
-    private val dvConfig: DbConfig,
+    private val dbConfig: DbConfig,
     private val database: Database,
 ) : AbstractJdbcLockProviderIntegrationTest() {
 
-    override fun getDbConfig(): DbConfig = dvConfig
+    override fun getDbConfig(): DbConfig = dbConfig
 
     override fun useDbTime(): Boolean = true
 

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/H2ExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/H2ExposedLockProviderIntegrationTest.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.sql.ExperimentalKeywordApi
 @OptIn(ExperimentalKeywordApi::class)
 class H2ExposedLockProviderIntegrationTest :
     AbstractExposedLockProviderIntegrationTest(
-        dvConfig = DB_CONFIG,
+        dbConfig = DB_CONFIG,
         database =
             Database.connect(DB_CONFIG.dataSource, databaseConfig = DatabaseConfig { preserveKeywordCasing = false }),
     ) {

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/H2ExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/H2ExposedLockProviderIntegrationTest.kt
@@ -1,0 +1,21 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import net.javacrumbs.shedlock.test.support.jdbc.H2Config
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
+import org.jetbrains.exposed.sql.ExperimentalKeywordApi
+
+@OptIn(ExperimentalKeywordApi::class)
+class H2ExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+    dvConfig = DB_CONFIG,
+    database = Database.connect(
+        DB_CONFIG.dataSource,
+        databaseConfig = DatabaseConfig {
+            preserveKeywordCasing = false
+        })
+) {
+
+    private companion object {
+        private val DB_CONFIG = H2Config()
+    }
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/H2ExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/H2ExposedLockProviderIntegrationTest.kt
@@ -6,14 +6,12 @@ import org.jetbrains.exposed.sql.DatabaseConfig
 import org.jetbrains.exposed.sql.ExperimentalKeywordApi
 
 @OptIn(ExperimentalKeywordApi::class)
-class H2ExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
-    dvConfig = DB_CONFIG,
-    database = Database.connect(
-        DB_CONFIG.dataSource,
-        databaseConfig = DatabaseConfig {
-            preserveKeywordCasing = false
-        })
-) {
+class H2ExposedLockProviderIntegrationTest :
+    AbstractExposedLockProviderIntegrationTest(
+        dvConfig = DB_CONFIG,
+        database =
+            Database.connect(DB_CONFIG.dataSource, databaseConfig = DatabaseConfig { preserveKeywordCasing = false }),
+    ) {
 
     private companion object {
         private val DB_CONFIG = H2Config()

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MariaDbExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MariaDbExposedLockProviderIntegrationTest.kt
@@ -1,0 +1,16 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import net.javacrumbs.shedlock.test.support.jdbc.MariaDbConfig
+import org.jetbrains.exposed.sql.Database
+
+class MariaDbExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+        dvConfig = DB_CONFIG,
+        database = Database.connect(DB_CONFIG.dataSource)
+) {
+
+    private companion object {
+        private val DB_CONFIG = object : MariaDbConfig() {
+            override fun nowExpression(): String = "current_timestamp(6)"
+        };
+    }
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MariaDbExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MariaDbExposedLockProviderIntegrationTest.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.sql.Database
 
 class MariaDbExposedLockProviderIntegrationTest :
     AbstractExposedLockProviderIntegrationTest(
-        dvConfig = DB_CONFIG,
+        dbConfig = DB_CONFIG,
         database = Database.connect(DB_CONFIG.dataSource),
     ) {
 

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MariaDbExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MariaDbExposedLockProviderIntegrationTest.kt
@@ -3,14 +3,16 @@ package net.javacrumbs.shedlock.provider.exposed
 import net.javacrumbs.shedlock.test.support.jdbc.MariaDbConfig
 import org.jetbrains.exposed.sql.Database
 
-class MariaDbExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+class MariaDbExposedLockProviderIntegrationTest :
+    AbstractExposedLockProviderIntegrationTest(
         dvConfig = DB_CONFIG,
-        database = Database.connect(DB_CONFIG.dataSource)
-) {
+        database = Database.connect(DB_CONFIG.dataSource),
+    ) {
 
     private companion object {
-        private val DB_CONFIG = object : MariaDbConfig() {
-            override fun nowExpression(): String = "current_timestamp(6)"
-        };
+        private val DB_CONFIG =
+            object : MariaDbConfig() {
+                override fun nowExpression(): String = "current_timestamp(6)"
+            }
     }
 }

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MsSqlExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MsSqlExposedLockProviderIntegrationTest.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.sql.Database
 
 class MsSqlExposedLockProviderIntegrationTest :
     AbstractExposedLockProviderIntegrationTest(
-        dvConfig = DB_CONFIG,
+        dbConfig = DB_CONFIG,
         database = Database.connect(DB_CONFIG.dataSource),
     ) {
 

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MsSqlExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MsSqlExposedLockProviderIntegrationTest.kt
@@ -1,13 +1,13 @@
 package net.javacrumbs.shedlock.provider.exposed
 
-import net.javacrumbs.shedlock.test.support.jdbc.MariaDbConfig
 import net.javacrumbs.shedlock.test.support.jdbc.MsSqlServerConfig
 import org.jetbrains.exposed.sql.Database
 
-class MsSqlExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+class MsSqlExposedLockProviderIntegrationTest :
+    AbstractExposedLockProviderIntegrationTest(
         dvConfig = DB_CONFIG,
-        database = Database.connect(DB_CONFIG.dataSource)
-) {
+        database = Database.connect(DB_CONFIG.dataSource),
+    ) {
 
     private companion object {
         private val DB_CONFIG = MsSqlServerConfig()

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MsSqlExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MsSqlExposedLockProviderIntegrationTest.kt
@@ -1,0 +1,15 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import net.javacrumbs.shedlock.test.support.jdbc.MariaDbConfig
+import net.javacrumbs.shedlock.test.support.jdbc.MsSqlServerConfig
+import org.jetbrains.exposed.sql.Database
+
+class MsSqlExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+        dvConfig = DB_CONFIG,
+        database = Database.connect(DB_CONFIG.dataSource)
+) {
+
+    private companion object {
+        private val DB_CONFIG = MsSqlServerConfig()
+    }
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MysqlExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MysqlExposedLockProviderIntegrationTest.kt
@@ -1,0 +1,16 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import net.javacrumbs.shedlock.test.support.jdbc.MySqlConfig
+import org.jetbrains.exposed.sql.Database
+
+class MysqlExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+        dvConfig = DB_CONFIG,
+        database = Database.connect(DB_CONFIG.dataSource)
+) {
+
+    private companion object {
+        private val DB_CONFIG = object : MySqlConfig() {
+            override fun nowExpression(): String = "current_timestamp(6)"
+        };
+    }
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MysqlExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MysqlExposedLockProviderIntegrationTest.kt
@@ -3,14 +3,16 @@ package net.javacrumbs.shedlock.provider.exposed
 import net.javacrumbs.shedlock.test.support.jdbc.MySqlConfig
 import org.jetbrains.exposed.sql.Database
 
-class MysqlExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+class MysqlExposedLockProviderIntegrationTest :
+    AbstractExposedLockProviderIntegrationTest(
         dvConfig = DB_CONFIG,
-        database = Database.connect(DB_CONFIG.dataSource)
-) {
+        database = Database.connect(DB_CONFIG.dataSource),
+    ) {
 
     private companion object {
-        private val DB_CONFIG = object : MySqlConfig() {
-            override fun nowExpression(): String = "current_timestamp(6)"
-        };
+        private val DB_CONFIG =
+            object : MySqlConfig() {
+                override fun nowExpression(): String = "current_timestamp(6)"
+            }
     }
 }

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MysqlExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/MysqlExposedLockProviderIntegrationTest.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.sql.Database
 
 class MysqlExposedLockProviderIntegrationTest :
     AbstractExposedLockProviderIntegrationTest(
-        dvConfig = DB_CONFIG,
+        dbConfig = DB_CONFIG,
         database = Database.connect(DB_CONFIG.dataSource),
     ) {
 

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/PostgresExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/PostgresExposedLockProviderIntegrationTest.kt
@@ -1,0 +1,18 @@
+package net.javacrumbs.shedlock.provider.exposed
+
+import net.javacrumbs.shedlock.test.support.jdbc.DbConfig
+import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig
+import org.jetbrains.exposed.sql.Database
+
+class PostgresExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+        dvConfig = DB_CONFIG,
+        database = Database.connect(DB_CONFIG.dataSource)
+) {
+    private companion object {
+        private val DB_CONFIG: DbConfig = object : PostgresConfig() {
+            override fun nowExpression(): String {
+                return "CURRENT_TIMESTAMP"
+            }
+        }
+    }
+}

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/PostgresExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/PostgresExposedLockProviderIntegrationTest.kt
@@ -6,7 +6,7 @@ import org.jetbrains.exposed.sql.Database
 
 class PostgresExposedLockProviderIntegrationTest :
     AbstractExposedLockProviderIntegrationTest(
-        dvConfig = DB_CONFIG,
+        dbConfig = DB_CONFIG,
         database = Database.connect(DB_CONFIG.dataSource),
     ) {
     private companion object {

--- a/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/PostgresExposedLockProviderIntegrationTest.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/kotlin/net/javacrumbs/shedlock/provider/exposed/PostgresExposedLockProviderIntegrationTest.kt
@@ -4,15 +4,17 @@ import net.javacrumbs.shedlock.test.support.jdbc.DbConfig
 import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig
 import org.jetbrains.exposed.sql.Database
 
-class PostgresExposedLockProviderIntegrationTest : AbstractExposedLockProviderIntegrationTest(
+class PostgresExposedLockProviderIntegrationTest :
+    AbstractExposedLockProviderIntegrationTest(
         dvConfig = DB_CONFIG,
-        database = Database.connect(DB_CONFIG.dataSource)
-) {
+        database = Database.connect(DB_CONFIG.dataSource),
+    ) {
     private companion object {
-        private val DB_CONFIG: DbConfig = object : PostgresConfig() {
-            override fun nowExpression(): String {
-                return "CURRENT_TIMESTAMP"
+        private val DB_CONFIG: DbConfig =
+            object : PostgresConfig() {
+                override fun nowExpression(): String {
+                    return "CURRENT_TIMESTAMP"
+                }
             }
-        }
     }
 }

--- a/providers/jdbc/shedlock-provider-exposed/src/test/resources/logback-test.xml
+++ b/providers/jdbc/shedlock-provider-exposed/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.zaxxer.hikari.HikariDataSource" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
I have added the Exposed provider. Currently, Exposed's R2DBC support is available in version 1.0.0-beta-2, but since it is still in beta, I proceeded with version 0.61.0 for now. 
Once version 1.0.0 is officially released, I plan to add R2DBC support.

related issue: #1232 