### PR TITLE
Try to fix Exposed flaky tests

### DIFF
--- a/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
+++ b/providers/jdbc/shedlock-provider-exposed/src/main/kotlin/net/javacrumbs/shedlock/provider/exposed/ExposedIntervalExpression.kt
@@ -16,12 +16,8 @@ private class IntervalExpression(private val expression: Expression<LocalDateTim
         when (currentDialect) {
             is SQLServerDialect -> {
                 queryBuilder.run {
-                    // SQL Server uses millisecond precision in datetime comparisons
-                    // Adding a small buffer (1ms less) to ensure time comparison behaves as expected
-                    val precisionAdjustedMillis = duration.toMillis() - 1
-
                     append("(DATEADD(millisecond, ")
-                    append(precisionAdjustedMillis.toString())
+                    append(duration.toMillis().toString())
                     append(", ")
                     expression.toQueryBuilder(queryBuilder)
                     append("))")


### PR DESCRIPTION
`lockAtLeastUntil greater now` should be true less often so `now` should be used more often as lock until 