### PR TITLE
Adds support for LockProvider using Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ executed repeatedly. Moreover, the locks are time-based and ShedLock assumes tha
   - [Memcached](#memcached-using-spymemcached)
   - [Datastore](#datastore)
   - [S3](#s3)
+  - [Firestore](#Firestore)
 + [Multi-tenancy](#multi-tenancy)
 + [Customization](#customization)
 + [Duration specification](#duration-specification)
@@ -952,6 +953,30 @@ import net.javacrumbs.shedlock.provider.s3v2.S3LockProvider;
 public LockProvider lockProvider(S3Client s3Client) {
     return new S3LockProvider(s3Client, "BUCKET_NAME");
 }
+
+```
+#### Firestore
+
+Import the project
+```xml
+<dependency>
+    <groupId>net.javacrumbs.shedlock</groupId>
+    <artifactId>shedlock-provider-firestore</artifactId>
+    <version>6.9.2</version>
+</dependency>
+```
+
+and configure
+```java
+import net.javacrumbs.shedlock.provider.firestore.FirestoreLockProvider;
+
+...
+
+@Bean
+public LockProvider lockProvider(com.google.cloud.firestore.Firestore firestore) {
+    return new FirestoreLockProvider(firestore);
+}
+
 ```
 
 ## Multi-tenancy

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <module>providers/neo4j/shedlock-provider-neo4j</module>
         <module>providers/s3/shedlock-provider-s3</module>
         <module>providers/s3/shedlock-provider-s3v2</module>
+        <module>providers/firestore/shedlock-provider-firestore</module>
     </modules>
 
     <properties>

--- a/providers/firestore/shedlock-provider-firestore/pom.xml
+++ b/providers/firestore/shedlock-provider-firestore/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <artifactId>shedlock-parent</artifactId>
+        <version>6.9.3-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>shedlock-provider-firestore</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <firestore.ver>3.31.7</firestore.ver>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-core</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-firestore</artifactId>
+            <version>${firestore.ver}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>gcloud</artifactId>
+            <version>${test-containers.ver}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.ver}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.ver}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${test-containers.ver}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.firestore
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/providers/firestore/shedlock-provider-firestore/src/main/java/net/javacrumbs/shedlock/provider/firestore/FirestoreLockProvider.java
+++ b/providers/firestore/shedlock-provider-firestore/src/main/java/net/javacrumbs/shedlock/provider/firestore/FirestoreLockProvider.java
@@ -1,0 +1,112 @@
+package net.javacrumbs.shedlock.provider.firestore;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.cloud.firestore.Firestore;
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+
+/**
+ * It uses a collection that contains documents like this:
+ *
+ * <pre>
+ * {
+ *    "name" : "lock name",
+ *    "lockUntil" :  {
+ *      "type":   "date",
+ *      "format": "epoch_millis"
+ *    },
+ *    "lockedAt" : {
+ *      "type":   "date",
+ *      "format": "epoch_millis"
+ *    }:
+ *    "lockedBy" : "hostname"
+ * }
+ * </pre>
+ *
+ * <p>
+ * lockedAt and lockedBy are just for troubleshooting and are not read by the
+ * code
+ *
+ * <ol>
+ * <li>Attempts to insert a new lock record. As an optimization, we keep
+ * in-memory track of created lock records. If the record has been inserted,
+ * returns lock.
+ * <li>We will try to update lock record using filter _id == name AND lock_until
+ * &lt;= now
+ * <li>If the update succeeded (1 updated document), we have the lock. If the
+ * update failed (0 updated documents) somebody else holds the lock
+ * <li>When unlocking, lock_until is set to now.
+ * </ol>
+ */
+public class FirestoreLockProvider extends StorageBasedLockProvider {
+
+    public FirestoreLockProvider(Firestore firestore) {
+        super(new FirestoreStorageAccessor(
+                Configuration.builder().withFirestore(firestore).build()));
+    }
+
+    public FirestoreLockProvider(Configuration configuration) {
+        super(new FirestoreStorageAccessor(configuration));
+    }
+
+    public static class Configuration {
+        private final String collectionName;
+        private final FieldNames fieldNames;
+        private final Firestore firestore;
+
+        Configuration(String entityName, FieldNames fieldNames, Firestore firestore) {
+            this.collectionName = requireNonNull(entityName);
+            this.fieldNames = requireNonNull(fieldNames);
+            this.firestore = requireNonNull(firestore);
+        }
+
+        public String getCollectionName() {
+            return collectionName;
+        }
+
+        public FieldNames getFieldNames() {
+            return fieldNames;
+        }
+
+        public Firestore getFirestore() {
+            return firestore;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+            private String collectionName = "lock";
+            private FieldNames fieldNames = new FieldNames("lock_until", "locked_at", "locked_by");
+            private Firestore firestore;
+
+            public Builder withCollectionName(String collectionName) {
+                this.collectionName = collectionName;
+                return this;
+            }
+
+            public Builder withFieldNames(FieldNames fieldNames) {
+                this.fieldNames = fieldNames;
+                return this;
+            }
+
+            public Builder withFirestore(Firestore firestore) {
+                this.firestore = firestore;
+                return this;
+            }
+
+            public Configuration build() {
+                return new Configuration(this.collectionName, this.fieldNames, this.firestore);
+            }
+        }
+    }
+
+    public record FieldNames(String lockUntil, String lockedAt, String lockedBy) {
+        public FieldNames(String lockUntil, String lockedAt, String lockedBy) {
+            this.lockUntil = requireNonNull(lockUntil);
+            this.lockedAt = requireNonNull(lockedAt);
+            this.lockedBy = requireNonNull(lockedBy);
+        }
+    }
+}

--- a/providers/firestore/shedlock-provider-firestore/src/main/java/net/javacrumbs/shedlock/provider/firestore/FirestoreStorageAccessor.java
+++ b/providers/firestore/shedlock-provider-firestore/src/main/java/net/javacrumbs/shedlock/provider/firestore/FirestoreStorageAccessor.java
@@ -1,0 +1,183 @@
+package net.javacrumbs.shedlock.provider.firestore;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.WriteBatch;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.support.AbstractStorageAccessor;
+import net.javacrumbs.shedlock.support.Utils;
+import net.javacrumbs.shedlock.support.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FirestoreStorageAccessor extends AbstractStorageAccessor {
+    private static final Logger log = LoggerFactory.getLogger(FirestoreStorageAccessor.class);
+
+    private final Firestore firestore;
+    private final String hostname;
+    private final String collectionName;
+    private final FirestoreLockProvider.FieldNames fieldNames;
+
+    public FirestoreStorageAccessor(FirestoreLockProvider.Configuration configuration) {
+        requireNonNull(configuration);
+        this.firestore = configuration.getFirestore();
+        this.hostname = Utils.getHostname();
+        this.collectionName = configuration.getCollectionName();
+        this.fieldNames = configuration.getFieldNames();
+    }
+
+    @Override
+    public boolean insertRecord(LockConfiguration config) {
+        return insert(config.getName(), config.getLockAtMostUntil());
+    }
+
+    @Override
+    public boolean updateRecord(LockConfiguration config) {
+        return updateExisting(config.getName(), config.getLockAtMostUntil());
+    }
+
+    @Override
+    public void unlock(LockConfiguration config) {
+        updateOwn(config.getName(), config.getUnlockTime());
+    }
+
+    @Override
+    public boolean extend(LockConfiguration config) {
+        return updateOwn(config.getName(), config.getLockAtMostUntil());
+    }
+
+    private boolean insert(String name, Instant until) {
+        // Firestore overrides the data if the document already exists, so we need to check if it exists first
+        ApiFuture<Boolean> future = firestore.runTransaction(transaction -> {
+            DocumentReference lockDocumentRef =
+                    firestore.collection(this.collectionName).document(name);
+            var snapshot = transaction.get(lockDocumentRef).get();
+            if (snapshot.exists()) {
+                return false;
+            }
+            Map<String, Object> data = new HashMap<>();
+            data.put(fieldNames.lockUntil(), fromInstant(until));
+            data.put(fieldNames.lockedAt(), fromInstant(ClockProvider.now()));
+            data.put(fieldNames.lockedBy(), this.hostname);
+            transaction.set(lockDocumentRef, data);
+            return true;
+        });
+        try {
+            return future.get();
+        } catch (Exception e) {
+            log.debug("Unable to perform a transactional unit of work: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean updateExisting(String name, Instant until) {
+        DocumentReference lockDocumentRef =
+                firestore.collection(this.collectionName).document(name);
+
+        if (Boolean.TRUE.equals(isLockExpired(lockDocumentRef))) {
+            WriteBatch writeBatch = firestore.batch();
+            writeBatch.update(lockDocumentRef, this.fieldNames.lockUntil(), fromInstant(until));
+            writeBatch.update(lockDocumentRef, this.fieldNames.lockedAt(), fromInstant(ClockProvider.now()));
+            writeBatch.update(lockDocumentRef, this.fieldNames.lockedBy(), this.hostname);
+            try {
+                writeBatch.commit().get();
+            } catch (Exception e) {
+                log.debug("Unable to perform a transactional unit of work: {}", e.getMessage());
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private Boolean isLockExpired(DocumentReference lockDocumentRef) {
+        try {
+            var now = ClockProvider.now();
+            var lockUntilTs = nullableTimestamp(lockDocumentRef, this.fieldNames.lockUntil());
+            return lockUntilTs != null && (lockUntilTs.isBefore(now) || lockUntilTs.equals(now));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private boolean updateOwn(String name, Instant until) {
+        DocumentReference lockDocumentRef =
+                firestore.collection(this.collectionName).document(name);
+
+        if (Boolean.TRUE.equals(isLockStillValidAndOwned(lockDocumentRef))) {
+            WriteBatch writeBatch = firestore.batch();
+            writeBatch.update(lockDocumentRef, this.fieldNames.lockUntil(), fromInstant(until));
+            try {
+                writeBatch.commit().get();
+            } catch (Exception e) {
+                log.debug("Unable to perform a transactional unit of work: {}", e.getMessage());
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private Boolean isLockStillValidAndOwned(DocumentReference lockDocumentRef) {
+        try {
+            var isOwner = this.hostname.equals(nullableString(lockDocumentRef, this.fieldNames.lockedBy()));
+            var now = ClockProvider.now();
+            var lockUntilTs = nullableTimestamp(lockDocumentRef, this.fieldNames.lockUntil());
+            return isOwner && (lockUntilTs != null && (lockUntilTs.isAfter(now) || lockUntilTs.equals(now)));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public Optional<Lock> findLock(String name) throws ExecutionException, InterruptedException {
+        DocumentReference lockDocumentRef =
+                firestore.collection(this.collectionName).document(name);
+        var snapshot = lockDocumentRef.get().get();
+        if (snapshot.exists()) {
+            return Optional.of(new Lock(
+                    snapshot.getId(),
+                    nullableTimestamp(lockDocumentRef, this.fieldNames.lockedAt()),
+                    nullableTimestamp(lockDocumentRef, this.fieldNames.lockUntil()),
+                    nullableString(lockDocumentRef, this.fieldNames.lockedBy())));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Nullable
+    private static String nullableString(DocumentReference documentReference, String property)
+            throws ExecutionException, InterruptedException {
+        return documentReference.get().get().contains(property)
+                ? (requireNonNull(documentReference.get().get().get(property)).toString())
+                : null;
+    }
+
+    @Nullable
+    private static Instant nullableTimestamp(DocumentReference documentReference, String property)
+            throws ExecutionException, InterruptedException {
+        return documentReference.get().get().contains(property)
+                ? toInstant((Timestamp) documentReference.get().get().get(property))
+                : null;
+    }
+
+    private static Timestamp fromInstant(Instant instant) {
+        return Timestamp.of(java.sql.Timestamp.from(requireNonNull(instant)));
+    }
+
+    private static Instant toInstant(Timestamp timestamp) {
+        return requireNonNull(timestamp).toSqlTimestamp().toInstant();
+    }
+
+    public record Lock(
+            String name, @Nullable Instant lockedAt, @Nullable Instant lockedUntil, @Nullable String lockedBy) {}
+}

--- a/providers/firestore/shedlock-provider-firestore/src/main/java/net/javacrumbs/shedlock/provider/firestore/package-info.java
+++ b/providers/firestore/shedlock-provider-firestore/src/main/java/net/javacrumbs/shedlock/provider/firestore/package-info.java
@@ -1,0 +1,6 @@
+@NonNullApi
+@NonNullFields
+package net.javacrumbs.shedlock.provider.firestore;
+
+import net.javacrumbs.shedlock.support.annotation.NonNullApi;
+import net.javacrumbs.shedlock.support.annotation.NonNullFields;

--- a/providers/firestore/shedlock-provider-firestore/src/main/resources/logback.xml
+++ b/providers/firestore/shedlock-provider-firestore/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright 2009 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/providers/firestore/shedlock-provider-firestore/src/test/java/net/javacrumbs/shedlock/provider/fiserstore/FirestoreLockProviderIntegrationTest.java
+++ b/providers/firestore/shedlock-provider-firestore/src/test/java/net/javacrumbs/shedlock/provider/fiserstore/FirestoreLockProviderIntegrationTest.java
@@ -1,0 +1,95 @@
+package net.javacrumbs.shedlock.provider.fiserstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.provider.firestore.FirestoreLockProvider;
+import net.javacrumbs.shedlock.provider.firestore.FirestoreStorageAccessor;
+import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
+import net.javacrumbs.shedlock.test.support.AbstractStorageBasedLockProviderIntegrationTest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class FirestoreLockProviderIntegrationTest extends AbstractStorageBasedLockProviderIntegrationTest {
+    private static final String PROJECT_ID = "shedlock-provider-datastore-test";
+    private static final String COLLECTION_NAME = "shedlock";
+
+    @Container
+    public static final GenericContainer<?> firestoreEmulator = new GenericContainer<>("mtlynch/firestore-emulator")
+            .withExposedPorts(8080)
+            .withEnv("FIRESTORE_PROJECT_ID", PROJECT_ID);
+
+    private Firestore firestore;
+    private FirestoreLockProvider provider;
+    private FirestoreStorageAccessor accessor;
+
+    @BeforeEach
+    void setUp() {
+        String host = firestoreEmulator.getHost();
+        Integer port = firestoreEmulator.getFirstMappedPort();
+        String emulatorHost = host + ":" + port;
+        System.setProperty("FIRESTORE_EMULATOR_HOST", emulatorHost);
+        FirestoreOptions options = FirestoreOptions.newBuilder()
+                .setProjectId(PROJECT_ID)
+                .setHost(emulatorHost)
+                .setCredentials(NoCredentials.getInstance())
+                .build();
+        firestore = options.getService();
+        FirestoreLockProvider.Configuration config = FirestoreLockProvider.Configuration.builder()
+                .withFirestore(firestore)
+                .withCollectionName(COLLECTION_NAME)
+                .withFieldNames(new FirestoreLockProvider.FieldNames("until", "at", "by"))
+                .build();
+        accessor = new FirestoreStorageAccessor(config);
+        provider = new FirestoreLockProvider(config);
+    }
+
+    @AfterEach
+    void cleanUp() throws Exception {
+        var locks = firestore.collection(COLLECTION_NAME).get().get().getDocuments();
+        for (var doc : locks) {
+            doc.getReference().delete().get();
+        }
+    }
+
+    @Override
+    protected StorageBasedLockProvider getLockProvider() {
+        return provider;
+    }
+
+    @Override
+    protected void assertLocked(@NotNull String lockName) {
+        var now = ClockProvider.now();
+        var lock = findLock(lockName).orElseThrow();
+        assertThat(lock.lockedUntil()).isAfter(now);
+        assertThat(lock.lockedAt()).isBefore(now);
+        assertThat(lock.lockedBy()).isNotEmpty();
+    }
+
+    @Override
+    protected void assertUnlocked(@NotNull String lockName) {
+        var now = ClockProvider.now();
+        var lock = findLock(lockName).orElseThrow();
+        assertThat(lock.lockedUntil()).isBefore(now);
+        assertThat(lock.lockedAt()).isBefore(now);
+        assertThat(lock.lockedBy()).isNotEmpty();
+    }
+
+    private Optional<FirestoreStorageAccessor.Lock> findLock(String lockName) {
+        try {
+            return accessor.findLock(lockName);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Failed to get lock from Firestore", e);
+        }
+    }
+}


### PR DESCRIPTION
Adds support for `firestore` based storage
- Implemeted FirestoreLockProvider using `com.google.cloud.firestore.Firestore`
- ImplementedLock acquisition, release using Firestore transaction construct
- Integration tests using Firestore emulator