### PR TITLE
enforce majority read/write concerns in MongoLockProvider

### DIFF
--- a/providers/mongo/shedlock-provider-mongo/src/main/java/net/javacrumbs/shedlock/provider/mongo/MongoLockProvider.java
+++ b/providers/mongo/shedlock-provider-mongo/src/main/java/net/javacrumbs/shedlock/provider/mongo/MongoLockProvider.java
@@ -21,6 +21,8 @@ import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.set;
 
 import com.mongodb.MongoServerException;
+import com.mongodb.ReadConcern;
+import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -104,6 +106,8 @@ public class MongoLockProvider implements ExtensibleLockProvider {
             // 3. The lock document exists and lockUtil > now - Duplicate key exception is
             // thrown
             getCollection()
+                .withReadConcern(ReadConcern.MAJORITY)
+                .withWriteConcern(WriteConcern.MAJORITY)
                     .findOneAndUpdate(
                             and(eq(ID, lockConfiguration.getName()), lte(LOCK_UNTIL, now)),
                             update,


### PR DESCRIPTION
This PR enforces ReadConcern.MAJORITY and WriteConcern.MAJORITY when acquiring a lock in MongoLockProvider.

## Motivation

In a MongoDB replica set, there is a potential issue:

A lock document can be written to the primary.

Before this change is replicated to the secondary, another scheduler instance might read from the secondary and incorrectly acquire the same lock.


## Impact

Pros: Stronger consistency, reduces risk of duplicate execution in replica set environments.

Cons: Slightly higher latency in lock operations.

Note: While this improves safety, it still does not provide a 100% guarantee of consistency. Certain edge cases (e.g., network partitions, failovers, or unexpected replication delays) may still cause rare anomalies.