### PR TITLE
feat: Add NATS JetStream lock provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ executed repeatedly. Moreover, the locks are time-based and ShedLock assumes tha
   - [Datastore](#datastore)
   - [Firestore](#firestore)
   - [S3](#s3)
+  - [NATS Jetstream](#nats-jetstream)
 + [Multi-tenancy](#multi-tenancy)
 + [Customization](#customization)
 + [Duration specification](#duration-specification)
@@ -958,6 +959,33 @@ import net.javacrumbs.shedlock.provider.s3v2.S3LockProvider;
 @Bean
 public LockProvider lockProvider(S3Client s3Client) {
     return new S3LockProvider(s3Client, "BUCKET_NAME");
+}
+```
+
+#### NATS JetStream
+The NATS JetStream provider uses a Key-Value (KV) store to manage locks. It operates out of a single, shared bucket named `shedlock-locks` by default, which is created automatically if it does not exist.
+
+Import the project:
+
+```xml
+<dependency>
+    <groupId>net.javacrumbs.shedlock</groupId>
+    <artifactId>shedlock-provider-jetstream</artifactId>
+    <version>7.1.0</version>
+</dependency>
+```
+
+Configure:
+
+```java
+import net.javacrumbs.shedlock.provider.nats.jetstream.NatsJetStreamLockProvider;
+import io.nats.client.Connection;
+
+...
+
+@Bean
+public LockProvider lockProvider(Connection natsConnection) {
+    return new NatsJetStreamLockProvider(natsConnection);
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <module>providers/neo4j/shedlock-provider-neo4j</module>
         <module>providers/s3/shedlock-provider-s3v2</module>
         <module>providers/firestore/shedlock-provider-firestore</module>
+        <module>providers/jetstream/shedlock-provider-jetstream</module>
     </modules>
 
     <properties>

--- a/providers/jetstream/shedlock-provider-jetstream/pom.xml
+++ b/providers/jetstream/shedlock-provider-jetstream/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>net.javacrumbs.shedlock</groupId>
+        <artifactId>shedlock-parent</artifactId>
+        <version>7.1.1-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shedlock-provider-jetstream</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <nats.version>2.23.0</nats.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.nats</groupId>
+            <artifactId>jnats</artifactId>
+            <version>${nats.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${test-containers.ver}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <version>${test-containers.ver}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.ver}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>
+                                net.javacrumbs.shedlock.provider.nats.jetstream
+                            </Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/providers/jetstream/shedlock-provider-jetstream/src/main/java/net/javacrumbs/shedlock/provider/nats/jetstream/NatsJetStreamLockProvider.java
+++ b/providers/jetstream/shedlock-provider-jetstream/src/main/java/net/javacrumbs/shedlock/provider/nats/jetstream/NatsJetStreamLockProvider.java
@@ -1,0 +1,167 @@
+package net.javacrumbs.shedlock.provider.nats.jetstream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.KeyValue;
+import io.nats.client.api.KeyValueConfiguration;
+import io.nats.client.api.StorageType;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import net.javacrumbs.shedlock.core.AbstractSimpleLock;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import net.javacrumbs.shedlock.support.LockException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Lock Provider for NATS JetStream
+ *
+ * <p>
+ * It uses a single bucket for all locks.
+ *
+ * @see <a href=
+ *      "https://docs.nats.io/nats-concepts/jetstream/key-value-store">KV</a>
+ */
+public class NatsJetStreamLockProvider implements LockProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(NatsJetStreamLockProvider.class);
+
+    private static final String BUCKET_NAME = "shedlock-locks";
+
+    private final KeyValue kv;
+
+    public NatsJetStreamLockProvider(final Connection connection) {
+        this(connection, BUCKET_NAME);
+    }
+
+    public NatsJetStreamLockProvider(final Connection connection, final String bucketName) {
+        requireNonNull(connection, "connection can not be null");
+        requireNonNull(bucketName, "bucketName can not be null");
+
+        KeyValue kvInit;
+        try {
+            kvInit = connection.keyValue(bucketName);
+        } catch (IOException e) {
+            logger.debug("Failed to get bucket '{}'. Trying to create it.", bucketName, e);
+
+            try {
+                var config = KeyValueConfiguration.builder()
+                        .name(bucketName)
+                        .storageType(StorageType.Memory)
+                        .build();
+
+                connection.keyValueManagement().create(config);
+                kvInit = connection.keyValue(bucketName);
+
+            } catch (IOException | JetStreamApiException ex) {
+                throw new LockException("Failed to create bucket", ex);
+            }
+        }
+        this.kv = kvInit;
+    }
+
+    @Override
+    public Optional<SimpleLock> lock(final LockConfiguration lockConfiguration) {
+        try {
+            var entry = kv.get(lockConfiguration.getName());
+
+            if (entry == null) {
+                return createLock(lockConfiguration);
+            }
+
+            var lockUntil = Instant.parse(new String(entry.getValue(), UTF_8));
+
+            if (lockUntil.isAfter(ClockProvider.now())) {
+                return Optional.empty();
+            }
+
+            return updateLock(lockConfiguration, entry.getRevision());
+
+        } catch (IOException | JetStreamApiException e) {
+            throw new LockException("Failed to get lock", e);
+        }
+    }
+
+    private Optional<SimpleLock> createLock(final LockConfiguration lockConfiguration) {
+        var lockUntil = lockConfiguration.getLockAtMostUntil();
+        var value = lockUntil.toString().getBytes(UTF_8);
+
+        try {
+            kv.create(lockConfiguration.getName(), value);
+            return Optional.of(new NatsJetStreamLock(this, lockConfiguration));
+
+        } catch (IOException | JetStreamApiException e) {
+            return Optional.empty(); // Should be caused by a race condition, another process was faster.
+        }
+    }
+
+    private Optional<SimpleLock> updateLock(final LockConfiguration lockConfiguration, final long revision) {
+        var lockUntil = lockConfiguration.getLockAtMostUntil();
+        var value = lockUntil.toString().getBytes(UTF_8);
+
+        try {
+            kv.update(lockConfiguration.getName(), value, revision);
+            return Optional.of(new NatsJetStreamLock(this, lockConfiguration));
+
+        } catch (IOException | JetStreamApiException e) {
+            return Optional.empty(); // Should be caused by a race condition, another process was faster.
+        }
+    }
+
+    private void unlock(final LockConfiguration lockConfiguration) {
+        var lockAtLeastUntil = lockConfiguration.getLockAtLeastUntil();
+        var now = ClockProvider.now();
+
+        try {
+            var entry = kv.get(lockConfiguration.getName());
+
+            if (entry == null) {
+                return; // Already unlocked
+            }
+
+            var lockUntil = Instant.parse(new String(entry.getValue(), UTF_8));
+            var lockAtMostUntil = lockConfiguration.getLockAtMostUntil();
+
+            // If the lock has been updated by another process, we don't unlock.
+            if (lockUntil.isAfter(lockAtMostUntil)) {
+                return;
+            }
+
+            // If lockAtLeastUntil is in the future, we update the lock to expire at
+            // lockAtLeastUntil instead of deleting it. This ensures the lock is held
+            // for the minimum duration.
+            if (lockAtLeastUntil.isAfter(now)) {
+                var value = lockAtLeastUntil.toString().getBytes(UTF_8);
+                kv.update(lockConfiguration.getName(), value, entry.getRevision());
+                return;
+            }
+
+            kv.delete(lockConfiguration.getName());
+        } catch (IOException | JetStreamApiException e) {
+            throw new LockException("Failed to unlock", e);
+        }
+    }
+
+    private static final class NatsJetStreamLock extends AbstractSimpleLock {
+
+        private final NatsJetStreamLockProvider lockProvider;
+
+        private NatsJetStreamLock(
+                final NatsJetStreamLockProvider lockProvider, final LockConfiguration lockConfiguration) {
+            super(lockConfiguration);
+            this.lockProvider = lockProvider;
+        }
+
+        @Override
+        public void doUnlock() {
+            lockProvider.unlock(lockConfiguration);
+        }
+    }
+}

--- a/providers/jetstream/shedlock-provider-jetstream/src/test/java/net/javacrumbs/shedlock/provider/nats/jetstream/NatsJetStreamContainer.java
+++ b/providers/jetstream/shedlock-provider-jetstream/src/test/java/net/javacrumbs/shedlock/provider/nats/jetstream/NatsJetStreamContainer.java
@@ -1,0 +1,27 @@
+package net.javacrumbs.shedlock.provider.nats.jetstream;
+
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+public class NatsJetStreamContainer extends GenericContainer<NatsJetStreamContainer> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NatsJetStreamContainer.class);
+
+    public static final DockerImageName NATS_IMAGE = DockerImageName.parse("nats:2.11-alpine");
+
+    private static final Integer NATS_PORT = 4222;
+
+    public NatsJetStreamContainer() {
+        super(NATS_IMAGE.asCanonicalNameString());
+        this.withExposedPorts(NATS_PORT)
+                .withNetworkAliases("nats")
+                .withLogConsumer(frame -> LOGGER.info(frame.getUtf8String().replace("\n", "")))
+                .withCommand("--jetstream")
+                .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Server is ready.*"))
+                .withStartupTimeout(Duration.ofSeconds(30L));
+    }
+}

--- a/providers/jetstream/shedlock-provider-jetstream/src/test/java/net/javacrumbs/shedlock/provider/nats/jetstream/NatsJetStreamLockProviderIntegrationTest.java
+++ b/providers/jetstream/shedlock-provider-jetstream/src/test/java/net/javacrumbs/shedlock/provider/nats/jetstream/NatsJetStreamLockProviderIntegrationTest.java
@@ -1,0 +1,82 @@
+package net.javacrumbs.shedlock.provider.nats.jetstream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.javacrumbs.shedlock.provider.nats.jetstream.NatsJetStreamContainer.NATS_IMAGE;
+import static net.javacrumbs.shedlock.test.support.DockerCleaner.removeImageInCi;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+import io.nats.client.api.KeyValueEntry;
+import java.time.Instant;
+import net.javacrumbs.shedlock.core.ClockProvider;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.test.support.AbstractLockProviderIntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class NatsJetStreamLockProviderIntegrationTest extends AbstractLockProviderIntegrationTest {
+
+    @Container
+    public static final NatsJetStreamContainer container = new NatsJetStreamContainer();
+
+    private LockProvider lockProvider;
+    private Connection connection;
+
+    @BeforeEach
+    void createLockProvider() throws Exception {
+        var natsUrl = String.format("nats://%s:%d", container.getHost(), container.getFirstMappedPort());
+        connection = Nats.connect(Options.builder().server(natsUrl).build());
+
+        lockProvider = new NatsJetStreamLockProvider(connection);
+    }
+
+    @AfterEach
+    void stopLockProvider() throws Exception {
+        connection.close();
+    }
+
+    @AfterAll
+    static void removeImage() {
+        removeImageInCi(NATS_IMAGE.asCanonicalNameString());
+    }
+
+    @Override
+    protected void assertUnlocked(String lockName) {
+        var entry = getLock(lockName);
+        if (entry != null) {
+            // If entry exists, check if the timestamp has expired
+            var lockUntil = Instant.parse(new String(entry.getValue(), UTF_8));
+            assertThat(lockUntil).isBefore(ClockProvider.now());
+        }
+    }
+
+    @Override
+    protected void assertLocked(String lockName) {
+        assertThat(getLock(lockName)).isNotNull();
+    }
+
+    @Override
+    protected LockProvider getLockProvider() {
+        return lockProvider;
+    }
+
+    private KeyValueEntry getLock(final String lockName) {
+        try {
+            return connection.keyValue("shedlock-locks").get(lockName);
+        } catch (JetStreamApiException e) {
+            if (e.getApiErrorCode() == 10059) { // Key not found
+                return null;
+            }
+            throw new IllegalStateException(e);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/providers/jetstream/shedlock-provider-jetstream/src/test/resources/logback.xml
+++ b/providers/jetstream/shedlock-provider-jetstream/src/test/resources/logback.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright 2009 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
   Implements distributed locking using NATS JetStream Key-Value store with:
   - NatsJetStreamLockProvider using KV bucket for lock storage
   - Optimistic locking with KV entry revisions
   - In-memory storage for ephemeral locks
   - Testcontainers-based integration tests
   - Documentation and usage examples
   
This simplified implementation does not use the TTL features of the NATS KV store. Just a stored timestamp. This allows all Shedlock features to be supported