### PR TITLE
Enable R2dbcLockProvider to Work in WebFlux Controllers

### DIFF
--- a/providers/r2dbc/shedlock-provider-r2dbc/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/R2dbcStorageAccessor.java
+++ b/providers/r2dbc/shedlock-provider-r2dbc/src/main/java/net/javacrumbs/shedlock/provider/r2dbc/R2dbcStorageAccessor.java
@@ -93,7 +93,7 @@ class R2dbcStorageAccessor extends AbstractStorageAccessor {
             if (cause instanceof LockException lockException) {
                 throw lockException;
             }
-            throw new LockException("Unexpected exception when executing r2dbc operation", cause);
+            throw new LockException("Unexpected exception when executing r2dbc operation", cause != null ? cause : e);
         } catch (TimeoutException e) {
             throw new LockException("Operation timed out", e);
         } catch (InterruptedException e) {


### PR DESCRIPTION
This PR enables R2dbcLockProvider to work properly when invoked from a WebFlux controller.


#3082 

After applying the changes in this PR, the lock works correctly when triggered through a WebFlux controller as well as through a scheduler.

I have tested this locally as well, and it works correctly without any issues.