### PR TITLE
Add optional DataSource-based isolation to JooqLockProvider (fixes #3683)

### DIFF
--- a/providers/jdbc/shedlock-provider-jooq/src/main/java/net/javacrumbs/shedlock/provider/jooq/JooqLockProvider.java
+++ b/providers/jdbc/shedlock-provider-jooq/src/main/java/net/javacrumbs/shedlock/provider/jooq/JooqLockProvider.java
@@ -13,6 +13,7 @@
  */
 package net.javacrumbs.shedlock.provider.jooq;
 
+import javax.sql.DataSource;
 import net.javacrumbs.shedlock.support.NewTransactionRunner;
 import net.javacrumbs.shedlock.support.StorageBasedLockProvider;
 import org.jooq.DSLContext;
@@ -24,5 +25,21 @@ public class JooqLockProvider extends StorageBasedLockProvider {
 
     public JooqLockProvider(DSLContext dslContext, NewTransactionRunner newTransactionRunner) {
         super(new JooqStorageAccessor(dslContext, newTransactionRunner));
+    }
+
+    /**
+     * Like {@link #JooqLockProvider(DSLContext)}, but every lock operation runs on a fresh
+     * connection obtained directly from {@code dataSource}, instead of whatever connection {@code
+     * dslContext} happens to be using. Unlike {@link #JooqLockProvider(DSLContext,
+     * NewTransactionRunner)}, this works even when {@code dslContext} is bound directly to a raw
+     * {@link java.sql.Connection} that may already have an ambient transaction open (e.g. {@code
+     * DSL.using(connection, dialect)}) - a construction {@code NewTransactionRunner} cannot help
+     * with, since it has no independent connection to switch to. Use this constructor if {@code
+     * dslContext} may be bound to a connection that is shared with, or participates in, a
+     * transaction the calling code manages itself, and {@code dslContext} isn't guaranteed to be
+     * Spring-transaction-aware.
+     */
+    public JooqLockProvider(DSLContext dslContext, DataSource dataSource) {
+        super(new JooqStorageAccessor(dslContext, dataSource));
     }
 }

--- a/providers/jdbc/shedlock-provider-jooq/src/main/java/net/javacrumbs/shedlock/provider/jooq/JooqStorageAccessor.java
+++ b/providers/jdbc/shedlock-provider-jooq/src/main/java/net/javacrumbs/shedlock/provider/jooq/JooqStorageAccessor.java
@@ -8,9 +8,11 @@ import static org.jooq.impl.DSL.localDateTimeAdd;
 import static org.jooq.impl.DSL.when;
 
 import java.io.Serializable;
+import java.sql.Connection;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
+import javax.sql.DataSource;
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.support.AbstractStorageAccessor;
 import net.javacrumbs.shedlock.support.LockException;
@@ -21,11 +23,14 @@ import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.TableField;
 import org.jooq.TransactionalCallable;
+import org.jooq.impl.DSL;
 import org.jooq.types.DayToSecond;
+import org.jspecify.annotations.Nullable;
 
 class JooqStorageAccessor extends AbstractStorageAccessor {
     private final DSLContext dslContext;
     private final NewTransactionRunner newTransactionRunner;
+    private final @Nullable DataSource dataSource;
     private final Shedlock t = SHEDLOCK;
 
     JooqStorageAccessor(DSLContext dslContext) {
@@ -35,6 +40,18 @@ class JooqStorageAccessor extends AbstractStorageAccessor {
     JooqStorageAccessor(DSLContext dslContext, NewTransactionRunner newTransactionRunner) {
         this.dslContext = requireNonNull(dslContext, "dslContext can not be null");
         this.newTransactionRunner = requireNonNull(newTransactionRunner, "newTransactionRunner can not be null");
+        this.dataSource = null;
+    }
+
+    /**
+     * Runs every lock operation on a fresh connection obtained directly from {@code dataSource},
+     * bypassing {@code dslContext}'s own connection entirely - see {@link
+     * JooqLockProvider#JooqLockProvider(DSLContext, DataSource)}.
+     */
+    JooqStorageAccessor(DSLContext dslContext, DataSource dataSource) {
+        this.dslContext = requireNonNull(dslContext, "dslContext can not be null");
+        this.dataSource = requireNonNull(dataSource, "dataSource can not be null");
+        this.newTransactionRunner = TransactionCallback::execute;
     }
 
     @Override
@@ -83,6 +100,9 @@ class JooqStorageAccessor extends AbstractStorageAccessor {
     }
 
     private <T> T runInTransaction(TransactionalCallable<T> txCallable) {
+        if (dataSource != null) {
+            return runOnIndependentConnection(txCallable);
+        }
         try {
             @SuppressWarnings("unchecked")
             T result = (T) newTransactionRunner.runInNewTransaction(() -> dslContext.transactionResult(txCallable));
@@ -90,6 +110,35 @@ class JooqStorageAccessor extends AbstractStorageAccessor {
         } catch (Exception e) {
             throw new LockException(e);
         } catch (Throwable e) {
+            throw new LockException(e);
+        }
+    }
+
+    /**
+     * Pulls a genuinely independent connection from {@code dataSource} and runs {@code
+     * txCallable} there, never touching whatever connection {@code dslContext} itself is bound
+     * to. This is what makes it safe even when {@code dslContext} is bound directly to a raw
+     * {@link Connection} that may already have an ambient transaction (and other, unrelated
+     * caller work) pending on it.
+     */
+    private <T> T runOnIndependentConnection(TransactionalCallable<T> txCallable) {
+        try (Connection connection = dataSource.getConnection()) {
+            boolean originalAutoCommit = connection.getAutoCommit();
+            if (!originalAutoCommit) {
+                connection.setAutoCommit(true);
+            }
+            try {
+                DSLContext isolatedDsl = DSL.using(
+                        connection,
+                        dslContext.configuration().dialect(),
+                        dslContext.configuration().settings());
+                return isolatedDsl.transactionResult(txCallable);
+            } finally {
+                if (!originalAutoCommit) {
+                    connection.setAutoCommit(false);
+                }
+            }
+        } catch (Exception e) {
             throw new LockException(e);
         }
     }

--- a/providers/jdbc/shedlock-provider-jooq/src/main/java/net/javacrumbs/shedlock/provider/jooq/JooqStorageAccessor.java
+++ b/providers/jdbc/shedlock-provider-jooq/src/main/java/net/javacrumbs/shedlock/provider/jooq/JooqStorageAccessor.java
@@ -100,8 +100,9 @@ class JooqStorageAccessor extends AbstractStorageAccessor {
     }
 
     private <T> T runInTransaction(TransactionalCallable<T> txCallable) {
-        if (dataSource != null) {
-            return runOnIndependentConnection(txCallable);
+        DataSource ds = dataSource;
+        if (ds != null) {
+            return runOnIndependentConnection(ds, txCallable);
         }
         try {
             @SuppressWarnings("unchecked")
@@ -121,7 +122,7 @@ class JooqStorageAccessor extends AbstractStorageAccessor {
      * {@link Connection} that may already have an ambient transaction (and other, unrelated
      * caller work) pending on it.
      */
-    private <T> T runOnIndependentConnection(TransactionalCallable<T> txCallable) {
+    private <T> T runOnIndependentConnection(DataSource dataSource, TransactionalCallable<T> txCallable) {
         try (Connection connection = dataSource.getConnection()) {
             boolean originalAutoCommit = connection.getAutoCommit();
             if (!originalAutoCommit) {

--- a/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/AmbientTransactionDoubleAcquireReproTest.java
+++ b/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/AmbientTransactionDoubleAcquireReproTest.java
@@ -1,0 +1,76 @@
+package net.javacrumbs.shedlock.provider.jooq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.time.Duration;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Follow-up: the stale-now() issue is not just a cosmetic timestamp discrepancy - it can break
+ * the actual mutual-exclusion guarantee. Node A has a long-lived ambient transaction open before
+ * it acquires the lock, so its lock_until is pinned to a stale, earlier now(). Node B connects
+ * fresh with no ambient transaction. With a short enough lockAtMostFor, Node B can steal the lock
+ * while Node A still believes it is well within lockAtMostFor.
+ */
+class AmbientTransactionDoubleAcquireReproTest {
+    private static final PostgresConfig dbConfig = new PostgresConfig();
+
+    @BeforeAll
+    static void startDb() {
+        dbConfig.startDb();
+    }
+
+    @AfterAll
+    static void shutdownDb() {
+        dbConfig.shutdownDb();
+    }
+
+    @Test
+    void two_nodes_can_hold_the_same_lock_at_the_same_time() throws Exception {
+        try (Connection setupConn = dbConfig.getDataSource().getConnection()) {
+            setupConn
+                    .createStatement()
+                    .execute(
+                            "CREATE TABLE IF NOT EXISTS shedlock(name VARCHAR(64) NOT NULL PRIMARY KEY, "
+                                    + "lock_until TIMESTAMP NOT NULL, locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL)");
+            setupConn.createStatement().execute("DELETE FROM shedlock");
+        }
+
+        Duration lockAtMostFor = Duration.ofSeconds(2);
+        LockConfiguration lockConfiguration =
+                new LockConfiguration(java.time.Instant.now(), "double-acquire-lock", lockAtMostFor, Duration.ZERO);
+
+        try (Connection nodeAConn = dbConfig.getDataSource().getConnection()) {
+            nodeAConn.setAutoCommit(false);
+            try (var ps = nodeAConn.prepareStatement("SELECT 1")) {
+                ps.executeQuery();
+            }
+            Thread.sleep(3000);
+
+            JooqStorageAccessor accessorA = new JooqStorageAccessor(DSL.using(nodeAConn, SQLDialect.POSTGRES));
+            boolean nodeAAcquired = accessorA.insertRecord(lockConfiguration);
+            assertThat(nodeAAcquired).isTrue();
+
+            try (Connection nodeBConn = dbConfig.getDataSource().getConnection()) {
+                DSLContext dslNodeB = DSL.using(nodeBConn, SQLDialect.POSTGRES);
+                JooqStorageAccessor accessorB = new JooqStorageAccessor(dslNodeB);
+
+                boolean nodeBAcquiredViaInsert = accessorB.insertRecord(lockConfiguration);
+                boolean nodeBAcquiredViaUpdate = !nodeBAcquiredViaInsert && accessorB.updateRecord(lockConfiguration);
+
+                assertThat(nodeBAcquiredViaInsert || nodeBAcquiredViaUpdate)
+                        .as("Node B should NOT be able to steal a lock Node A just acquired with a 2s "
+                                + "lockAtMostFor, unless jOOQ's stale-now() bug lets it")
+                        .isTrue();
+            }
+        }
+    }
+}

--- a/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/AmbientTransactionStaleNowReproTest.java
+++ b/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/AmbientTransactionStaleNowReproTest.java
@@ -1,0 +1,80 @@
+package net.javacrumbs.shedlock.provider.jooq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduction: when the DSLContext given to JooqLockProvider (default, no DataSource) is bound
+ * directly to a raw Connection that already has an open transaction, lock_until is computed from
+ * that transaction's stale snapshot instead of the actual current time. FuzzTester never exercises
+ * this, since it calls the lock provider directly with no ambient transaction.
+ */
+class AmbientTransactionStaleNowReproTest {
+    private static final PostgresConfig dbConfig = new PostgresConfig();
+
+    @BeforeAll
+    static void startDb() {
+        dbConfig.startDb();
+    }
+
+    @AfterAll
+    static void shutdownDb() {
+        dbConfig.shutdownDb();
+    }
+
+    @Test
+    void lock_until_is_computed_from_stale_transaction_snapshot_not_actual_now() throws Exception {
+        try (Connection setupConn = dbConfig.getDataSource().getConnection()) {
+            setupConn
+                    .createStatement()
+                    .execute(
+                            "CREATE TABLE IF NOT EXISTS shedlock(name VARCHAR(64) NOT NULL PRIMARY KEY, "
+                                    + "lock_until TIMESTAMP NOT NULL, locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL)");
+            setupConn.createStatement().execute("DELETE FROM shedlock");
+        }
+
+        try (Connection ambientConn = dbConfig.getDataSource().getConnection()) {
+            ambientConn.setAutoCommit(false);
+
+            LocalDateTime txSnapshotAtStart;
+            try (PreparedStatement ps = ambientConn.prepareStatement("SELECT CURRENT_TIMESTAMP")) {
+                ResultSet rs = ps.executeQuery();
+                rs.next();
+                txSnapshotAtStart = rs.getTimestamp(1).toLocalDateTime();
+            }
+            Thread.sleep(3000);
+
+            DSLContext dslOnAmbientConnection = DSL.using(ambientConn, SQLDialect.POSTGRES);
+            JooqStorageAccessor accessor = new JooqStorageAccessor(dslOnAmbientConnection);
+
+            boolean inserted = accessor.insertRecord(
+                    new LockConfiguration(java.time.Instant.now(), "repro-lock", Duration.ofMinutes(5), Duration.ZERO));
+            assertThat(inserted).isTrue();
+
+            LocalDateTime lockUntilRecorded;
+            try (PreparedStatement ps =
+                    ambientConn.prepareStatement("SELECT lock_until FROM shedlock WHERE name = 'repro-lock'")) {
+                ResultSet rs = ps.executeQuery();
+                rs.next();
+                lockUntilRecorded = rs.getTimestamp(1).toLocalDateTime();
+            }
+
+            assertThat(Duration.between(txSnapshotAtStart, lockUntilRecorded))
+                    .as("lock_until should equal txSnapshotAtStart + 5min if the stale snapshot was used")
+                    .isCloseTo(Duration.ofMinutes(5), Duration.ofSeconds(1));
+        }
+    }
+}

--- a/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/JooqStorageAccessorDataSourceFixTest.java
+++ b/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/JooqStorageAccessorDataSourceFixTest.java
@@ -1,0 +1,87 @@
+package net.javacrumbs.shedlock.provider.jooq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the JooqLockProvider(DSLContext, DataSource) constructor fixes both problems that a
+ * raw-Connection-bound DSLContext otherwise has: (a) lock_until is computed from the real current
+ * time rather than a stale ambient-transaction snapshot, and (b) the caller's own unrelated
+ * pending work on that connection is never touched or force-committed, and still rolls back
+ * cleanly afterward.
+ */
+class JooqStorageAccessorDataSourceFixTest {
+    private static final PostgresConfig dbConfig = new PostgresConfig();
+
+    @BeforeAll
+    static void startDb() {
+        dbConfig.startDb();
+    }
+
+    @AfterAll
+    static void shutdownDb() {
+        dbConfig.shutdownDb();
+    }
+
+    @Test
+    void usesRealCurrentTime_andNeverTouchesCallersOwnConnection() throws Exception {
+        try (Connection setupConn = dbConfig.getDataSource().getConnection()) {
+            setupConn
+                    .createStatement()
+                    .execute(
+                            "CREATE TABLE IF NOT EXISTS shedlock(name VARCHAR(64) NOT NULL PRIMARY KEY, "
+                                    + "lock_until TIMESTAMP NOT NULL, locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL)");
+            setupConn.createStatement().execute("CREATE TABLE IF NOT EXISTS marker(id INT PRIMARY KEY)");
+            setupConn.createStatement().execute("DELETE FROM shedlock");
+            setupConn.createStatement().execute("DELETE FROM marker");
+        }
+
+        try (Connection callerConn = dbConfig.getDataSource().getConnection()) {
+            callerConn.setAutoCommit(false);
+            try (var stmt = callerConn.createStatement()) {
+                stmt.execute("INSERT INTO marker(id) VALUES (1)");
+            }
+            Thread.sleep(3000);
+
+            DSLContext callerDsl = DSL.using(callerConn, SQLDialect.POSTGRES);
+            JooqStorageAccessor accessor = new JooqStorageAccessor(callerDsl, dbConfig.getDataSource());
+
+            LocalDateTime realNow = LocalDateTime.now();
+            boolean acquired = accessor.insertRecord(
+                    new LockConfiguration(java.time.Instant.now(), "fix-lock", Duration.ofMinutes(5), Duration.ZERO));
+            assertThat(acquired).isTrue();
+
+            // (a) lock_until reflects the real current time, not a stale ambient snapshot.
+            LocalDateTime lockUntil;
+            try (var stmt = callerConn.createStatement();
+                    var rs = stmt.executeQuery("SELECT lock_until FROM shedlock WHERE name = 'fix-lock'")) {
+                rs.next();
+                lockUntil = rs.getTimestamp(1).toLocalDateTime();
+            }
+            assertThat(Duration.between(realNow, lockUntil)).isCloseTo(Duration.ofMinutes(5), Duration.ofSeconds(2));
+
+            // (b) the caller's own unrelated pending work is untouched and still rolls back cleanly.
+            callerConn.rollback();
+        }
+
+        try (Connection verifyConn = dbConfig.getDataSource().getConnection();
+                var stmt = verifyConn.createStatement();
+                var rs = stmt.executeQuery("SELECT COUNT(*) FROM marker")) {
+            rs.next();
+            assertThat(rs.getInt(1))
+                    .as("caller's own uncommitted work must not have been force-committed by the lock call")
+                    .isZero();
+        }
+    }
+}

--- a/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/JooqStorageAccessorDataSourceFixTest.java
+++ b/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/JooqStorageAccessorDataSourceFixTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.sql.Connection;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig;
 import org.jooq.DSLContext;
@@ -57,7 +58,7 @@ class JooqStorageAccessorDataSourceFixTest {
             DSLContext callerDsl = DSL.using(callerConn, SQLDialect.POSTGRES);
             JooqStorageAccessor accessor = new JooqStorageAccessor(callerDsl, dbConfig.getDataSource());
 
-            LocalDateTime realNow = LocalDateTime.now();
+            LocalDateTime realNow = LocalDateTime.now(ZoneId.systemDefault());
             boolean acquired = accessor.insertRecord(
                     new LockConfiguration(java.time.Instant.now(), "fix-lock", Duration.ofMinutes(5), Duration.ZERO));
             assertThat(acquired).isTrue();

--- a/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/SilentPrematureCommitMatrixTest.java
+++ b/providers/jdbc/shedlock-provider-jooq/src/test/java/net/javacrumbs/shedlock/provider/jooq/SilentPrematureCommitMatrixTest.java
@@ -1,0 +1,219 @@
+package net.javacrumbs.shedlock.provider.jooq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.time.Duration;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.test.support.jdbc.PostgresConfig;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exhaustive matrix for the "silent premature commit" side effect: when JooqLockProvider's
+ * DSLContext shares a connection with the caller's OWN unrelated, not-yet-committed work, a single
+ * lock call force-commits that work - regardless of whether the lock is actually acquired, and
+ * regardless of whether the caller later tries to roll back. Also verifies that using a genuinely
+ * separate connection (the DataSource-based approach) avoids all of this entirely.
+ */
+class SilentPrematureCommitMatrixTest {
+    private static final PostgresConfig dbConfig = new PostgresConfig();
+
+    @BeforeAll
+    static void startDb() {
+        dbConfig.startDb();
+    }
+
+    @AfterAll
+    static void shutdownDb() {
+        dbConfig.shutdownDb();
+    }
+
+    private void resetTables() throws Exception {
+        try (Connection setupConn = dbConfig.getDataSource().getConnection()) {
+            setupConn
+                    .createStatement()
+                    .execute(
+                            "CREATE TABLE IF NOT EXISTS shedlock(name VARCHAR(64) NOT NULL PRIMARY KEY, "
+                                    + "lock_until TIMESTAMP NOT NULL, locked_at TIMESTAMP NOT NULL, locked_by VARCHAR(255) NOT NULL)");
+            setupConn.createStatement().execute("CREATE TABLE IF NOT EXISTS marker(id INT PRIMARY KEY)");
+            setupConn.createStatement().execute("DELETE FROM shedlock");
+            setupConn.createStatement().execute("DELETE FROM marker");
+        }
+    }
+
+    private int markerCountFromFreshConnection() throws Exception {
+        try (Connection freshConn = dbConfig.getDataSource().getConnection();
+                var stmt = freshConn.createStatement();
+                var rs = stmt.executeQuery("SELECT COUNT(*) FROM marker")) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+
+    // 1. Baseline (already proven, re-verified here): one successful lock call commits caller's work.
+    @Test
+    void successfulLockCall_commitsCallersOtherPendingWork() throws Exception {
+        resetTables();
+        try (Connection ambientConn = dbConfig.getDataSource().getConnection()) {
+            ambientConn.setAutoCommit(false);
+            try (var stmt = ambientConn.createStatement()) {
+                stmt.execute("INSERT INTO marker(id) VALUES (1)");
+            }
+            assertThat(markerCountFromFreshConnection()).isZero();
+
+            JooqStorageAccessor accessor = new JooqStorageAccessor(DSL.using(ambientConn, SQLDialect.POSTGRES));
+            boolean acquired = accessor.insertRecord(
+                    new LockConfiguration(java.time.Instant.now(), "lock-1", Duration.ofMinutes(5), Duration.ZERO));
+
+            assertThat(acquired).isTrue();
+            System.out.println("[1] marker count after SUCCESSFUL lock call: " + markerCountFromFreshConnection());
+            assertThat(markerCountFromFreshConnection()).isEqualTo(1);
+        }
+    }
+
+    // 2. Does a FAILED lock attempt (someone else already holds it) ALSO force-commit caller's work?
+    @Test
+    void failedLockAttempt_stillCommitsCallersOtherPendingWork() throws Exception {
+        resetTables();
+        // Someone else already holds "lock-2" (a completely independent, already-committed lock).
+        try (Connection winnerConn = dbConfig.getDataSource().getConnection()) {
+            JooqStorageAccessor winner = new JooqStorageAccessor(DSL.using(winnerConn, SQLDialect.POSTGRES));
+            winner.insertRecord(
+                    new LockConfiguration(java.time.Instant.now(), "lock-2", Duration.ofMinutes(5), Duration.ZERO));
+        }
+
+        try (Connection ambientConn = dbConfig.getDataSource().getConnection()) {
+            ambientConn.setAutoCommit(false);
+            try (var stmt = ambientConn.createStatement()) {
+                stmt.execute("INSERT INTO marker(id) VALUES (1)");
+            }
+            assertThat(markerCountFromFreshConnection()).isZero();
+
+            JooqStorageAccessor accessor = new JooqStorageAccessor(DSL.using(ambientConn, SQLDialect.POSTGRES));
+            // This attempt LOSES the race - lock-2 is already held.
+            boolean acquired = accessor.insertRecord(
+                    new LockConfiguration(java.time.Instant.now(), "lock-2", Duration.ofMinutes(5), Duration.ZERO));
+
+            assertThat(acquired).isFalse();
+            System.out.println("[2] marker count after FAILED (losing) lock call: " + markerCountFromFreshConnection());
+            // Even a losing attempt still runs inside (and commits) the top-level transaction.
+            assertThat(markerCountFromFreshConnection()).isEqualTo(1);
+        }
+    }
+
+    // 3. If the caller INTENDED to roll back (e.g. a downstream validation failure), does the lock
+    // call's forced commit make that rollback silently ineffective for the already-committed part?
+    @Test
+    void callerIntendedRollback_isDefeated_byLockCallsForcedCommit() throws Exception {
+        resetTables();
+        try (Connection ambientConn = dbConfig.getDataSource().getConnection()) {
+            ambientConn.setAutoCommit(false);
+            try (var stmt = ambientConn.createStatement()) {
+                stmt.execute("INSERT INTO marker(id) VALUES (1)");
+            }
+
+            JooqStorageAccessor accessor = new JooqStorageAccessor(DSL.using(ambientConn, SQLDialect.POSTGRES));
+            accessor.insertRecord(
+                    new LockConfiguration(java.time.Instant.now(), "lock-3", Duration.ofMinutes(5), Duration.ZERO));
+
+            // Simulate the caller later deciding something went wrong and rolling back.
+            ambientConn.rollback();
+
+            System.out.println("[3] marker count after caller's explicit rollback (post lock call): "
+                    + markerCountFromFreshConnection());
+            // The rollback is too late - marker(1) was already committed by the lock call.
+            assertThat(markerCountFromFreshConnection()).isEqualTo(1);
+        }
+    }
+
+    // 4. Does MULTIPLE prior pending writes (not just one row) all get swept into the forced commit?
+    @Test
+    void multiplePendingWrites_areAllCommitted_byOneLockCall() throws Exception {
+        resetTables();
+        try (Connection ambientConn = dbConfig.getDataSource().getConnection()) {
+            ambientConn.setAutoCommit(false);
+            try (var stmt = ambientConn.createStatement()) {
+                stmt.execute("INSERT INTO marker(id) VALUES (1)");
+                stmt.execute("INSERT INTO marker(id) VALUES (2)");
+                stmt.execute("INSERT INTO marker(id) VALUES (3)");
+            }
+            assertThat(markerCountFromFreshConnection()).isZero();
+
+            JooqStorageAccessor accessor = new JooqStorageAccessor(DSL.using(ambientConn, SQLDialect.POSTGRES));
+            accessor.insertRecord(
+                    new LockConfiguration(java.time.Instant.now(), "lock-4", Duration.ofMinutes(5), Duration.ZERO));
+
+            System.out.println("[4] marker count after lock call (3 unrelated rows pending before it): "
+                    + markerCountFromFreshConnection());
+            assertThat(markerCountFromFreshConnection()).isEqualTo(3);
+        }
+    }
+
+    // 5. unlock() and extend() also force-commit, not just insertRecord().
+    @Test
+    void unlockAndExtend_alsoForceCommit_callersOtherPendingWork() throws Exception {
+        resetTables();
+        try (Connection ambientConn = dbConfig.getDataSource().getConnection()) {
+            ambientConn.setAutoCommit(false);
+            JooqStorageAccessor accessor = new JooqStorageAccessor(DSL.using(ambientConn, SQLDialect.POSTGRES));
+            LockConfiguration lockConfiguration =
+                    new LockConfiguration(java.time.Instant.now(), "lock-5", Duration.ofMinutes(1), Duration.ZERO);
+            accessor.insertRecord(lockConfiguration); // this alone already commits, so add new pending work after
+
+            try (var stmt = ambientConn.createStatement()) {
+                stmt.execute("INSERT INTO marker(id) VALUES (1)");
+            }
+            assertThat(markerCountFromFreshConnection()).isZero();
+
+            accessor.extend(
+                    new LockConfiguration(java.time.Instant.now(), "lock-5", Duration.ofMinutes(5), Duration.ZERO));
+            System.out.println("[5a] marker count after extend(): " + markerCountFromFreshConnection());
+            assertThat(markerCountFromFreshConnection()).isEqualTo(1);
+
+            try (var stmt = ambientConn.createStatement()) {
+                stmt.execute("INSERT INTO marker(id) VALUES (2)");
+            }
+            assertThat(markerCountFromFreshConnection()).isEqualTo(1); // id=2 not committed yet
+
+            accessor.unlock(lockConfiguration);
+            System.out.println("[5b] marker count after unlock(): " + markerCountFromFreshConnection());
+            assertThat(markerCountFromFreshConnection()).isEqualTo(2);
+        }
+    }
+
+    // 6. Control: a genuinely SEPARATE connection (the DataSource-based idea) never touches the
+    // caller's own connection/transaction at all, so none of the above can happen.
+    @Test
+    void separateConnection_neverCommitsCallersOtherPendingWork() throws Exception {
+        resetTables();
+        try (Connection ambientConn = dbConfig.getDataSource().getConnection()) {
+            ambientConn.setAutoCommit(false);
+            try (var stmt = ambientConn.createStatement()) {
+                stmt.execute("INSERT INTO marker(id) VALUES (1)");
+            }
+            assertThat(markerCountFromFreshConnection()).isZero();
+
+            // The lock call runs on a COMPLETELY SEPARATE connection obtained fresh from the
+            // DataSource - never touches ambientConn at all.
+            try (Connection lockConn = dbConfig.getDataSource().getConnection()) {
+                JooqStorageAccessor accessor = new JooqStorageAccessor(DSL.using(lockConn, SQLDialect.POSTGRES));
+                boolean acquired = accessor.insertRecord(
+                        new LockConfiguration(java.time.Instant.now(), "lock-6", Duration.ofMinutes(5), Duration.ZERO));
+                assertThat(acquired).isTrue();
+            }
+
+            System.out.println(
+                    "[6] marker count after lock call on a SEPARATE connection: " + markerCountFromFreshConnection());
+            // Caller's own pending work is completely untouched.
+            assertThat(markerCountFromFreshConnection()).isZero();
+
+            // And the caller can still decide to roll back cleanly afterward.
+            ambientConn.rollback();
+            assertThat(markerCountFromFreshConnection()).isZero();
+        }
+    }
+}


### PR DESCRIPTION

### What

Adds an opt-in constructor overload, `JooqLockProvider(DSLContext, DataSource)`. When a `DataSource` is provided, every lock operation (`insertRecord`, `updateRecord`, `unlock`, `extend`) runs on a fresh connection obtained directly from it, instead of whatever connection the `DSLContext` happens to be using. The existing single-arg `JooqLockProvider(DSLContext)` constructor is unchanged and remains the default - this is purely additive.

### Why

See #3683 for the full writeup. Short version of the mechanism: `JooqStorageAccessor` runs lock operations through `dslContext.transactionResult(txCallable)`, which goes through jOOQ's `DefaultTransactionProvider`. That class caches whatever `autoCommit` value the connection had when it first saw it, and if that was already `false` (i.e. the connection already had an open transaction), it correctly leaves `setAutoCommit()` alone - but `commit()` has no matching guard:

```java
// org.jooq.impl.DefaultTransactionProvider
public final void commit(TransactionContext ctx) {
    ...
    if (savepoints.isEmpty()) {
        connection(ctx).commit();   // unconditional, regardless of the connection's original autoCommit state
        brace(ctx, false);
    }
}
```

So if the `DSLContext` given to `JooqLockProvider` is bound to a connection that's sharing an ambient transaction with something else the caller was doing, a single lock operation force-commits that connection - including whatever the caller had already written on it and not yet committed - whether or not the lock attempt itself succeeds.

I verified this holds across every operation and several edge cases (`SilentPrematureCommitMatrixTest`, `DefaultJooqCommitBehaviorProbeTest`):

```
successful lock call                                    -> caller's pending row: committed
failed/losing lock attempt                               -> caller's pending row: still committed
rollback() called on the caller's connection after the fact -> too late, no effect
3 unrelated pending rows before one lock call             -> all 3 committed
extend() / unlock()                                       -> same behavior as insertRecord()
lock call on a genuinely separate connection (DataSource-based) -> caller's row: untouched, rollback() still works
```

A realistic way to hit this: a batch job that opens one `Connection` manually and writes several related rows via jOOQ, meaning to commit-or-rollback them together at the end - a common pattern in code that manages its own transaction boundaries rather than relying on Spring's `@Transactional` (and also how jOOQ's own getting-started docs introduce `DSL.using(connection, dialect)`, before a `DataSource`-backed setup). 
If that same connection/`DSLContext` also gets used partway through to acquire a ShedLock lock, everything written before that point is committed right then regardless of what the batch decides afterward - no error, no log.

`JdbcStorageAccessor` and `JdbcTemplateStorageAccessor` don't have this problem because they already require a `DataSource` and never touch the caller's own connection at all. `NewTransactionRunner` (7.9.0, for #3577) fixes a related but narrower case: when `DSLContext`'s connection provider is itself Spring-registry-aware (`TransactionAwareDataSourceProxy`), Spring's `REQUIRES_NEW` can suspend the caller's connection and redirect jOOQ to a new one. 

But `DefaultConnectionProvider` (what backs `DSL.using(connection, dialect)`) just holds the one `Connection` it was constructed with and always returns that same instance - there's no registry for `NewTransactionRunner` to redirect through, so it can't help here. The only way to guarantee the caller's connection is never touched is to not use it in the first place, which needs a `DataSource`.

### Why not just toggle autocommit on the DSLContext's existing connection (no new API)?

I tried that first, since it needs no new constructor - `dslContext.configuration().connectionProvider()` gives back the `Connection`, which can be autocommit-toggled the same way `JdbcStorageAccessor` does. But per the JDBC spec, calling `setAutoCommit(true)` on a connection with an open transaction commits it - so this reproduces the identical forced-commit problem described above, just triggered by my own code instead of jOOQ's `DefaultTransactionProvider.commit()`. Pulling a genuinely separate connection is the only way to avoid it.

### Changes

- `JooqLockProvider`: new `JooqLockProvider(DSLContext, DataSource)` constructor, javadoc explaining when to use it.
- `JooqStorageAccessor`: takes an optional `DataSource`. When present, lock operations run via a connection pulled directly from `dataSource` (autocommit temporarily forced to `true` if needed, restored afterward, mirroring `JdbcStorageAccessor`), using a `DSLContext` derived from the original one's dialect/settings. When absent, behavior is unchanged from before this PR.
- New tests in `shedlock-provider-jooq`:
  - `SilentPrematureCommitMatrixTest` - the matrix above: successful/failed lock attempts, multiple pending rows, `extend()`/`unlock()`, and the separate-connection control case, all with the default (no-`DataSource`) constructor.
  - `JooqStorageAccessorDataSourceFixTest` - with the `DataSource` constructor: the caller's own pending work is never touched and still rolls back cleanly, and `lock_until` is computed from the real current time (the `DataSource`-based fix incidentally also resolves the timestamp-staleness issue from #3682/#3577, since it never shares a connection with an ambient transaction in the first place).
  - `AmbientTransactionStaleNowReproTest`, `AmbientTransactionDoubleAcquireReproTest` - carried over from the earlier #3682 investigation; document that the default constructor still reproduces the timestamp symptom too.

### Test plan

Full `shedlock-provider-jooq` module test suite, including all existing Postgres/MySQL/MariaDB/HSQLDB integration tests, passes unmodified alongside the new tests:

```
Tests run: 95, Failures: 0, Errors: 0, Skipped: 2
BUILD SUCCESS
```

(2 skipped tests are pre-existing/unrelated to this change.)

### Backward compatibility

Fully additive. The existing `JooqLockProvider(DSLContext)` constructor and its behavior are untouched; users who don't opt in see no change.
